### PR TITLE
Fix incorrect command call in object detection demos

### DIFF
--- a/object-detector-cpp/config/env.armv7hf
+++ b/object-detector-cpp/config/env.armv7hf
@@ -1,3 +1,3 @@
 MODEL_PATH=/models/ssd_mobilenet_v2_coco_quant_postprocess_edgetpu.tflite
 INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:0.6-armv7hf
-INFERENCE_SERVER_COMMAND=/usr/bin/larod-inference-server -p 8501 -j 4 -c /models/server.pem -k /models/server.key
+INFERENCE_SERVER_COMMAND=/usr/bin/acap_runtime -p 8501 -j 4 -c /models/server.pem -k /models/server.key

--- a/object-detector-python/config/env.armv7hf
+++ b/object-detector-python/config/env.armv7hf
@@ -1,3 +1,3 @@
 MODEL_PATH=/models/ssd_mobilenet_v2_coco_quant_postprocess_edgetpu.tflite
 INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:0.6-armv7hf
-INFERENCE_SERVER_COMMAND=/usr/bin/larod-inference-server -p 8501 -j 4 
+INFERENCE_SERVER_COMMAND=/usr/bin/acap_runtime -p 8501 -j 4 


### PR DESCRIPTION
The object detection demos are currently calling a non-existing `larod-inference-server`` command. I was able to get the demos running by changing it to `acap_runtime`.