### PR TITLE
Convert RGB to BGR format when encoding to show the correct color on webpage

### DIFF
--- a/pose-estimator-with-flask/app/detector_with_flask.py
+++ b/pose-estimator-with-flask/app/detector_with_flask.py
@@ -41,7 +41,8 @@ def gen():
             time.sleep(1)
             continue
 
-        frame = cv2.imencode('.jpg', frame)[1].tobytes()
+        # Convert RGB to BGR format when encoding to keep the correct color
+        frame = cv2.imencode('.jpg', cv2.cvtColor(frame, cv2.COLOR_RGB2BGR))[1].tobytes()
         yield b'Content-Type: image/jpeg\r\n\r\n' + frame + b'\r\n--frame\r\n'
 
 
@@ -136,8 +137,6 @@ class Detector:
     # Run object detection on video stream
     def get_frame(self):
         _, frame = self.cap.read()
-        # Convert the frame color channel from BGR to RGB
-        frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
         # Cut the central area of the frame of a 1920x1080 to make it square
         frame = frame[:, 420:-420, :]
         small_frame = cv2.resize(frame, (192, 192), interpolation=cv2.INTER_AREA)

--- a/pose-estimator-with-flask/app/detector_with_flask.py
+++ b/pose-estimator-with-flask/app/detector_with_flask.py
@@ -136,6 +136,8 @@ class Detector:
     # Run object detection on video stream
     def get_frame(self):
         _, frame = self.cap.read()
+        # Convert the frame color channel from BGR to RGB
+        frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
         # Cut the central area of the frame of a 1920x1080 to make it square
         frame = frame[:, 420:-420, :]
         small_frame = cv2.resize(frame, (192, 192), interpolation=cv2.INTER_AREA)


### PR DESCRIPTION
Convert the frame color format to BGR when encoding because cv2.imencode is expecting the BGR format.

### Describe your changes

Please include a summary of the change, a relevant motivation and context.

### Issue ticket number and link

- Fixes #(issue)

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
