### PR TITLE
RLIMIT_NOFILE overwritten value

### DIFF
--- a/web-server/README.md
+++ b/web-server/README.md
@@ -76,7 +76,7 @@ docker save $APP_NAME | docker --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT
 
 # Start Web Server on the camera
 ```sh
-docker --tlsverify  -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT run --rm -p 8080:80 -it $APP_NAME
+docker --tlsverify  -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT run --rm -p 8080:2001 -it $APP_NAME
 ```
 
 ### The expected output
@@ -86,7 +86,7 @@ Monkey HTTP Server v1.5.6
 Built : Jun 18 2021 11:05:42 (arm-linux-gnueabihf-gcc -mthumb -mfpu=neon -mfloat-abi=hard -mcpu=cortex-a9 9.3.0)
 Home  : http://monkey-project.com
 [+] Process ID is 6
-[+] Server socket listening on Port 80
+[+] Server socket listening on Port 2001
 [+] 2 threads, 253 client connections per thread, total 506
 [+] Transport layer by liana in http mode
 [+] Linux Features: TCP_FASTOPEN SO_REUSEPORT

--- a/web-server/monkey.patch
+++ b/web-server/monkey.patch
@@ -203,3 +203,23 @@ index 9914cb79..383f841f 100644
  
  	mklib_stop(ctx);
  
+diff --git a/src/mk_server.c b/src/mk_server.c
+index 8c27742..956f7ee 100644
+--- a/src/mk_server.c
++++ b/src/mk_server.c
+@@ -40,11 +40,9 @@
+ unsigned int mk_server_worker_capacity(unsigned short nworkers)
+ {
+     unsigned int max, avl;
+-    struct rlimit lim;
+-
+-    /* Limit by system */
+-    getrlimit(RLIMIT_NOFILE, &lim);
+-    max = lim.rlim_cur;
++    
++    /* Overwrite the value for RLIMIT_NOFILE to avoid unmanagable memory allocation */
++    max = 1048576;
+ 
+     /* Minimum of fds needed by Monkey:
+      * --------------------------------
+  


### PR DESCRIPTION
### Describe your changes

RLIMIT_NOFILE overwritten value. Monkey relies on this value and containerd was updated to have it set to infinity by default, so this sets a value, specifically to the value that containerd previously used.

### Issue ticket number and link

- Fixes [#(issue)](https://github.com/AxisCommunications/acap-computer-vision-sdk-examples/issues/29)

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
