### PR TITLE
Remove reference to COCO labels file

### DIFF
--- a/pose-estimator-with-flask/docker-compose.yml
+++ b/pose-estimator-with-flask/docker-compose.yml
@@ -16,10 +16,8 @@ services:
       - INFERENCE_HOST=unix:///tmp/acap-runtime.sock
       - INFERENCE_PORT=0
       - MODEL_PATH=${MODEL_PATH}
-      - OBJECT_LIST_PATH=/models/coco_labels.txt
     volumes:
       - /usr/lib/libvdostream.so.1:/usr/lib/libvdostream.so.1
-      - acap_dl-models:/models:ro
       - /tmp:/output
       - /var/run/dbus:/var/run/dbus:rw
       - inference-server:/tmp


### PR DESCRIPTION
### Describe your changes
In the docker compose file the acap_dl-models volume was mounted in the
pose-estimator container and an environment variable specified the path
to a COCO dataset labels file. This file does not exist and the
environment variable is never used, it thus seems like the extra lines
in the docker compose file are leftovers from the object-detector-python
example.

### Issue ticket number and link

- Fixes #(issue)

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
