### PR TITLE
Consolidate variable names

### DIFF
--- a/hello-world-cross-compiled/README.md
+++ b/hello-world-cross-compiled/README.md
@@ -51,14 +51,14 @@ export ARCH=aarch64
 
 ```sh
 # Set camera IP
-export AXIS_TARGET_IP=<actual camera IP address>
-export DOCKER_PORT=2376
+DEVICE_IP=<actual camera IP address>
+DOCKER_PORT=2376
 
 # Define APP name
-export APP_NAME=hello-world-cross-compiled
+APP_NAME=hello-world-cross-compiled
 
 # Clean docker memory
-docker --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT system prune -af
+docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
 ```
 
 ### Build and run the images
@@ -72,16 +72,16 @@ docker build . -t $APP_NAME --build-arg ARCH
 Next, the built image needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
 
 ```sh
-docker save $APP_NAME | docker --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT  load
+docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 ```
 
 With the application image on the device, it can be started. As the example uses OpenCV, the OpenCV requirements will be included in `docker-compose.yml`, which is used to run the application:
 
 ```sh
-docker-compose --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT up
+docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT up
 
 # Cleanup after execution
-docker-compose --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT down -v
+docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT down -v
 ```
 
 The expected output from the application is (depending on the OpenCV pulled from the ACAP Computer Vision SDK):

--- a/hello-world/README.md
+++ b/hello-world/README.md
@@ -51,14 +51,14 @@ export ARCH=aarch64
 
 ```sh
 # Set camera IP
-export AXIS_TARGET_IP=<actual camera IP address>
-export DOCKER_PORT=2376
+DEVICE_IP=<actual camera IP address>
+DOCKER_PORT=2376
 
 # Define APP name
-export APP_NAME=hello-world
+APP_NAME=hello-world
 
 # Clean docker memory
-docker --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT system prune -af
+docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
 ```
 
 ### Build and run the images
@@ -72,16 +72,16 @@ docker build . -t $APP_NAME --build-arg ARCH
 Next, the built image needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
 
 ```sh
-docker save $APP_NAME | docker --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT  load
+docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 ```
 
 With the application image on the device, it can be started. As this example does not use e.g., OpenCV, no special mounts are needed, making the `docker-compose.yml` file very simple:
 
 ```sh
-docker-compose --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT up
+docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT up
 
 # Cleanup after execution
-docker-compose --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT down -v
+docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT down -v
 ```
 
 The expected output from the application is simply:

--- a/minimal-ml-inference/README.md
+++ b/minimal-ml-inference/README.md
@@ -62,34 +62,34 @@ export CHIP=artpec8
 ### Set your camera IP address and clear Docker memory
 
 ```sh
-export AXIS_TARGET_IP=<actual camera IP address>
-export DOCKER_PORT=2376
-docker --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT system prune -af
+DEVICE_IP=<actual camera IP address>
+DOCKER_PORT=2376
+docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
 ```
 
 ### Build the minimal-ml-inference images
 
 ```sh
 # Define APP name
-export APP_NAME=acap4-minimal-ml-inference
-export MODEL_NAME=acap-dl-models
+APP_NAME=acap4-minimal-ml-inference
+MODEL_NAME=acap-dl-models
 
 # Install qemu to allow build flask for a different architecture
 docker run -it --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
 
 # Build and upload inference client for camera
 docker build . -t $APP_NAME --build-arg ARCH
-docker save $APP_NAME | docker --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT load
+docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 
 # Build and upload inference models
 docker build . -f Dockerfile.model -t $MODEL_NAME --build-arg ARCH
-docker save $MODEL_NAME | docker --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT load
+docker save $MODEL_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 
 # Use the following command to run the example on the camera
-docker-compose --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP up
+docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP up
 
 # Terminate with Ctrl-C and cleanup
-docker-compose --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP down -v
+docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP down -v
 ```
 
 The expected output from the application is the raw predictions from the model specified in the environment variable.

--- a/object-detector-cpp/README.md
+++ b/object-detector-cpp/README.md
@@ -71,34 +71,34 @@ export CHIP=artpec8
 ### Set your camera IP address and clear Docker memory
 
 ```sh
-export AXIS_TARGET_IP=<actual camera IP address>
-export DOCKER_PORT=2376
-docker --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT system prune -af
+DEVICE_IP=<actual camera IP address>
+DOCKER_PORT=2376
+docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
 ```
 
 ### Build the object-detector-cpp images
 
 ```sh
 # Define APP name
-export APP_NAME=acap4-object-detector-cpp
-export MODEL_NAME=acap-dl-models
+APP_NAME=acap4-object-detector-cpp
+MODEL_NAME=acap-dl-models
 
 # Install qemu to allow build flask for a different architecture
 docker run -it --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
 
 # Build and upload inference client for camera
 docker build . -t $APP_NAME --build-arg ARCH
-docker save $APP_NAME | docker --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT load
+docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 
 # Build and upload inference models
 docker build . -f Dockerfile.model -t $MODEL_NAME --build-arg ARCH
-docker save $MODEL_NAME | docker --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT load
+docker save $MODEL_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 
 # Use the following command to run the example on the camera
-docker-compose --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP up
+docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP up
 
 # Terminate with Ctrl-C and cleanup
-docker-compose --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP down -v
+docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP down -v
 ```
 
 ### The expected output

--- a/object-detector-python/README.md
+++ b/object-detector-python/README.md
@@ -85,47 +85,47 @@ export CHIP=artpec8
 ### Set your camera IP address and clear Docker memory
 
 ```sh
-export AXIS_TARGET_IP=<actual camera IP address>
-export DOCKER_PORT=2376
-docker -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT system prune -af
+DEVICE_IP=<actual camera IP address>
+DOCKER_PORT=2376
+docker -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
 ```
 
 ### Build the object-detector-python images
 
 ```sh
 # Define APP name
-export APP_NAME=acap4-object-detector-python
-export MODEL_NAME=acap-dl-models
+APP_NAME=acap4-object-detector-python
+MODEL_NAME=acap-dl-models
 
 # Install qemu to allow build flask for a different architecture
 docker run -it --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
 
 # Build and upload inference client for camera
 docker build . -t $APP_NAME --build-arg ARCH
-docker save $APP_NAME | docker --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT load
+docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 
 # Build and upload inference models
 docker build . -f Dockerfile.model -t $MODEL_NAME --build-arg ARCH
-docker save $MODEL_NAME | docker --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT load
+docker save $MODEL_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 
 # Use the following command to run the example on the camera
-docker-compose --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP up
+docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP up
 
 # Terminate with Ctrl-C and cleanup
-docker-compose --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP down -v
+docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP down -v
 ```
 
 ### The expected output
 
 ```sh
-docker-compose --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP up
+docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP up
 ....
 object-detector_1           | 1 Objects found
 object-detector_1           | person
 ```
 
 ```sh
-docker-compose --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT -f static-image.yml --env-file ./config/env.$ARCH.$CHIP up
+docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT -f static-image.yml --env-file ./config/env.$ARCH.$CHIP up
 ....
 object-detector-python_1          | 3 Objects found
 object-detector-python_1          | bicycle

--- a/opencv-image-capture-cpp/README.md
+++ b/opencv-image-capture-cpp/README.md
@@ -69,13 +69,13 @@ export ARCH=aarch64
 
 ```sh
 # Set camera IP
-export AXIS_TARGET_IP=<actual camera IP address>
-export DOCKER_PORT=2376
+DEVICE_IP=<actual camera IP address>
+DOCKER_PORT=2376
 
 # Define APP name
-export APP_NAME=acap-opencv-image-capture-cpp
+APP_NAME=acap-opencv-image-capture-cpp
 # Clean docker memory
-docker --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT system prune -af
+docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
 ```
 
 ### Build and run the images
@@ -83,12 +83,12 @@ docker --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT system prune -af
 ```sh
 docker build . -t $APP_NAME --build-arg ARCH
 
-docker save $APP_NAME | docker --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT  load
+docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 
-docker-compose --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT -f docker-compose.yml up
+docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT -f docker-compose.yml up
 
 # Cleanup
-docker-compose --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT -f docker-compose.yml down -v
+docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT -f docker-compose.yml down -v
 ```
 
 #### The expected output

--- a/opencv-qr-decoder-python/README.md
+++ b/opencv-qr-decoder-python/README.md
@@ -53,14 +53,14 @@ export ARCH=aarch64
 
 ```sh
 # Set camera IP
-export AXIS_TARGET_IP=<actual camera IP address>
-export DOCKER_PORT=2376
+DEVICE_IP=<actual camera IP address>
+DOCKER_PORT=2376
 
 # Define APP name
-export APP_NAME=acap-opencv-qr-decoder-python
+APP_NAME=acap-opencv-qr-decoder-python
 
 # Clean docker memory
-docker --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT system prune -af
+docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
 ```
 
 ### Build and run the images
@@ -74,16 +74,16 @@ docker build . -t $APP_NAME --build-arg ARCH
 Next, the built image needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
 
 ```sh
-docker save $APP_NAME | docker --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT  load
+docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 ```
 
 With the application image on the device, it can be started. As the example uses OpenCV, the OpenCV requirements will be included in `docker-compose.yml`, which is used to run the application:
 
 ```sh
-docker-compose --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT up
+docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT up
 
 # Cleanup after execution
-docker-compose --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT down -v
+docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT down -v
 ```
 
 ## License

--- a/parameter-api-cpp/README.md
+++ b/parameter-api-cpp/README.md
@@ -70,7 +70,7 @@ export ARCH=aarch64
 
 ```sh
 # Define app name
-export APP_NAME=parameter-api
+APP_NAME=parameter-api
 
 # Build
 docker build . -t $APP_NAME --build-arg ARCH
@@ -79,10 +79,10 @@ docker build . -t $APP_NAME --build-arg ARCH
 ### Set your camera IP address and clear Docker memory
 
 ```sh
-export AXIS_TARGET_IP=<actual camera IP address>
-export DOCKER_PORT=2376
+DEVICE_IP=<actual camera IP address>
+DOCKER_PORT=2376
 
-docker --tlsverify --tlscacert ca.pem --tlscert cert.pem --tlskey key.pem -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT system prune -af
+docker --tlsverify --tlscacert ca.pem --tlscert cert.pem --tlskey key.pem -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
 ```
 
 where `ca.pem`, `cert.pem` and `key.pem` are the certificates generated when configuring TLS on Docker ACAP.
@@ -99,13 +99,13 @@ Certificate files for TLS are created in the build process of this example and m
 
 ```sh
 docker cp $(docker create $APP_NAME):/certificates .
-scp certificates/* root@$AXIS_TARGET_IP:/usr/local/packages/acapruntime
+scp certificates/* root@$DEVICE_IP:/usr/local/packages/acapruntime
 ```
 
 Use SSH to change the ownership of the files on the device:
 
 ```sh
-ssh root@$AXIS_TARGET_IP 'chown sdk /usr/local/packages/acapruntime/server.*'
+ssh root@$DEVICE_IP 'chown sdk /usr/local/packages/acapruntime/server.*'
 ```
 
 After copying the server certificates onto the device, we have to make sure to enable TLS and then restart the ACAP-runtime.
@@ -114,10 +114,10 @@ After copying the server certificates onto the device, we have to make sure to e
 AXIS_TARGET_PASSWORD='<password>'
 
 # Enable TLS
-curl --anyauth -u "root:$AXIS_TARGET_PASSWORD" "$AXIS_TARGET_IP/axis-cgi/param.cgi?action=update&acapruntime.UseTLS=yes"
+curl --anyauth -u "root:$AXIS_TARGET_PASSWORD" "$DEVICE_IP/axis-cgi/param.cgi?action=update&acapruntime.UseTLS=yes"
 
 # Restart ACAP
-curl --anyauth -u "root:$AXIS_TARGET_PASSWORD" "$AXIS_TARGET_IP/axis-cgi/applications/control.cgi?package=acapruntime&action=restart"
+curl --anyauth -u "root:$AXIS_TARGET_PASSWORD" "$DEVICE_IP/axis-cgi/applications/control.cgi?package=acapruntime&action=restart"
 ```
 
 where `<password>` is the password to the `root` user.
@@ -125,7 +125,7 @@ where `<password>` is the password to the `root` user.
 Finally install the Docker image to the device:
 
 ```sh
-docker save $APP_NAME | docker --tlsverify --tlscacert ca.pem --tlscert cert.pem --tlskey key.pem -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT load
+docker save $APP_NAME | docker --tlsverify --tlscacert ca.pem --tlscert cert.pem --tlskey key.pem -H tcp://$DEVICE_IP:$DOCKER_PORT load
 ```
 
 where `ca.pem`, `cert.pem` and `key.pem` are the certificates generated when configuring TLS on Docker ACAP.
@@ -135,7 +135,7 @@ where `ca.pem`, `cert.pem` and `key.pem` are the certificates generated when con
 Use the following command to run the example on the device:
 
 ```sh
-docker-compose --tlsverify --tlscacert ca.pem --tlscert cert.pem --tlskey key.pem -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT up
+docker-compose --tlsverify --tlscacert ca.pem --tlscert cert.pem --tlskey key.pem -H tcp://$DEVICE_IP:$DOCKER_PORT up
 ```
 
 where `ca.pem`, `cert.pem` and `key.pem` are the certificates generated when configuring TLS on Docker ACAP.

--- a/parameter-api-python/README.md
+++ b/parameter-api-python/README.md
@@ -68,7 +68,7 @@ export ARCH=aarch64
 
 ```sh
 # Define app name
-export APP_NAME=parameter-api
+APP_NAME=parameter-api
 
 # Build
 docker build . -t $APP_NAME --build-arg ARCH
@@ -77,10 +77,10 @@ docker build . -t $APP_NAME --build-arg ARCH
 ### Set your camera IP address and clear Docker memory
 
 ```sh
-export AXIS_TARGET_IP=<actual camera IP address>
-export DOCKER_PORT=2376
+DEVICE_IP=<actual camera IP address>
+DOCKER_PORT=2376
 
-docker --tlsverify --tlscacert ca.pem --tlscert cert.pem --tlskey key.pem -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT system prune -af
+docker --tlsverify --tlscacert ca.pem --tlscert cert.pem --tlskey key.pem -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
 ```
 
 where `ca.pem`, `cert.pem` and `key.pem` are the certificates generated when configuring TLS on Docker ACAP.
@@ -97,13 +97,13 @@ Certificate files for TLS are created in the build process of this example and m
 
 ```sh
 docker cp $(docker create $APP_NAME):/certificates .
-scp certificates/* root@$AXIS_TARGET_IP:/usr/local/packages/acapruntime
+scp certificates/* root@$DEVICE_IP:/usr/local/packages/acapruntime
 ```
 
 Use SSH to change the ownership of the files on the device:
 
 ```sh
-ssh root@$AXIS_TARGET_IP 'chown sdk /usr/local/packages/acapruntime/server.*'
+ssh root@$DEVICE_IP 'chown sdk /usr/local/packages/acapruntime/server.*'
 ```
 
 After copying the server certificates onto the device, we have to make sure to enable TLS and then restart the ACAP-runtime.
@@ -112,10 +112,10 @@ After copying the server certificates onto the device, we have to make sure to e
 AXIS_TARGET_PASSWORD='<password>'
 
 # Enable TLS
-curl --anyauth -u "root:$AXIS_TARGET_PASSWORD" "$AXIS_TARGET_IP/axis-cgi/param.cgi?action=update&acapruntime.UseTLS=yes"
+curl --anyauth -u "root:$AXIS_TARGET_PASSWORD" "$DEVICE_IP/axis-cgi/param.cgi?action=update&acapruntime.UseTLS=yes"
 
 # Restart ACAP
-curl --anyauth -u "root:$AXIS_TARGET_PASSWORD" "$AXIS_TARGET_IP/axis-cgi/applications/control.cgi?package=acapruntime&action=restart"
+curl --anyauth -u "root:$AXIS_TARGET_PASSWORD" "$DEVICE_IP/axis-cgi/applications/control.cgi?package=acapruntime&action=restart"
 ```
 
 where `<password>` is the password to the `root` user.
@@ -123,7 +123,7 @@ where `<password>` is the password to the `root` user.
 Finally install the Docker image to the device:
 
 ```sh
-docker save $APP_NAME | docker --tlsverify --tlscacert ca.pem --tlscert cert.pem --tlskey key.pem -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT load
+docker save $APP_NAME | docker --tlsverify --tlscacert ca.pem --tlscert cert.pem --tlskey key.pem -H tcp://$DEVICE_IP:$DOCKER_PORT load
 ```
 
 where `ca.pem`, `cert.pem` and `key.pem` are the certificates generated when configuring TLS on Docker ACAP.
@@ -133,7 +133,7 @@ where `ca.pem`, `cert.pem` and `key.pem` are the certificates generated when con
 Use the following command to run the example on the device:
 
 ```sh
-docker-compose --tlsverify --tlscacert ca.pem --tlscert cert.pem --tlskey key.pem -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT up
+docker-compose --tlsverify --tlscacert ca.pem --tlscert cert.pem --tlskey key.pem -H tcp://$DEVICE_IP:$DOCKER_PORT up
 ```
 
 where `ca.pem`, `cert.pem` and `key.pem` are the certificates generated when configuring TLS on Docker ACAP.

--- a/pose-estimator-with-flask/README.md
+++ b/pose-estimator-with-flask/README.md
@@ -97,13 +97,13 @@ export CHIP=artpec8
 ### Set your camera IP address and clear Docker memory
 
 ```sh
-export AXIS_TARGET_IP=<actual camera IP address>
-export DOCKER_PORT=2376
+DEVICE_IP=<actual camera IP address>
+DOCKER_PORT=2376
 
 # Define APP name
-export APP_NAME=acap4-pose-estimator-python
-export MODEL_NAME=acap-dl-models
-docker --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT system prune -af
+APP_NAME=acap4-pose-estimator-python
+MODEL_NAME=acap-dl-models
+docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
 ```
 
 ### Build the pose-estimator-with-flask images
@@ -114,22 +114,22 @@ docker run -it --rm --privileged multiarch/qemu-user-static --credential yes --p
 
 # Build and upload inference client for camera
 docker build . -t $APP_NAME --build-arg ARCH
-docker save $APP_NAME | docker --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT load
+docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 
 # Build and upload inference models
 docker build . -f Dockerfile.model -t $MODEL_NAME --build-arg ARCH
-docker save $MODEL_NAME | docker --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT load
+docker save $MODEL_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 
 # Use the following command to run the example on the camera
-docker-compose --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP up
+docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP up
 
 # Terminate with Ctrl-C and cleanup
-docker-compose --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP down -v
+docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP down -v
 ```
 
 ### The expected output
 
-In your browser, go to http://$AXIS_TARGET_IP:5000 to start the interference. If a person is detected, the key points are drawn on the video stream.
+In your browser, go to http://$DEVICE_IP:5000 to start the interference. If a person is detected, the key points are drawn on the video stream.
 
 ![Pose estimator](assets/frame_36.jpg)
 

--- a/web-server/README.md
+++ b/web-server/README.md
@@ -69,13 +69,13 @@ export ARCH=aarch64
 
 ```sh
 # Set camera IP
-export AXIS_TARGET_IP=<actual camera IP address>
-export DOCKER_PORT=2376
+DEVICE_IP=<actual camera IP address>
+DOCKER_PORT=2376
 
 # Define APP name
-export APP_NAME=monkey
+APP_NAME=monkey
 # Clean docker memory
-docker --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT system prune -af
+docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
 ```
 
 ### Build and run the images
@@ -93,7 +93,7 @@ docker build . -t $APP_NAME --build-arg ARCH
 Next, the built image needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
 
 ```sh
-docker save $APP_NAME | docker --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT  load
+docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 ```
 
 ### Start Web Server on the camera
@@ -101,10 +101,10 @@ docker save $APP_NAME | docker --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT
 With the application image on the device, it can be started using `docker-compose.yml`:
 
 ```sh
-docker-compose --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT up
+docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT up
 
 # Cleanup after execution
-docker-compose --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT down -v
+docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT down -v
 ```
 
 ### The expected output
@@ -128,13 +128,13 @@ Some C API examples are included in the Web Server container that has been built
 
 ```sh
 # Run the hello example
-docker --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT  run --rm -p 2001:2001 -it $APP_NAME hello
+docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT  run --rm -p 2001:2001 -it $APP_NAME hello
 
 # Run the list directory example
-docker --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT  run --rm -p 2001:2001 -it $APP_NAME list
+docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT  run --rm -p 2001:2001 -it $APP_NAME list
 
 # Run the quiz example
-docker --tlsverify -H tcp://$AXIS_TARGET_IP:$DOCKER_PORT  run --rm -p 2001:2001 -it $APP_NAME quiz
+docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT  run --rm -p 2001:2001 -it $APP_NAME quiz
 ```
 
 ## Proxy settings


### PR DESCRIPTION
### Describe your changes

Let's be consistent when it comes to usage of variable names. In Docker ACAP and Docker Compose ACAP we use `DEVICE_IP` instead of `AXIS_TARGET_IP`, let's do so here as well. I've also removed exporting some variables that didn't need exporting. Is there any downside to just define the variables, to not export them?

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that my code follows the style already available in the repository

