### PR TITLE
Fix Dockerfile syntax to resolve bug when build

### DIFF
--- a/minimal-ml-inference/Dockerfile.model
+++ b/minimal-ml-inference/Dockerfile.model
@@ -12,9 +12,9 @@ FROM arm64v8/ubuntu:${UBUNTU_VERSION} as local-aarch64
 FROM local-${ARCH} as local
 
 RUN <<EOF
-apt-get update
-apt-get install -y -f openssl
-EOF
+RUN apt-get update
+RUN apt-get install -y -f openssl
+RUN <<EOF
 
 # Generate TSL/SSL test certificate
 RUN openssl req -x509 -batch -subj '/CN=localhost' -days 10000 -newkey rsa:4096 -nodes -out server.pem -keyout server.key

--- a/object-detector-cpp/Dockerfile
+++ b/object-detector-cpp/Dockerfile
@@ -18,18 +18,18 @@ ENV https_proxy=${HTTP_PROXY}
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-apt-get update
-apt-get install -y -f libglib2.0-dev libsystemd0
-apt-get clean
-rm -rf /var/lib/apt/lists/*
-EOF
+RUN apt-get update
+RUN apt-get install -y -f libglib2.0-dev libsystemd0
+RUN apt-get clean
+RUN rm -rf /var/lib/apt/lists/*
+RUN <<EOF
 
 RUN mkdir -p /tmp/devel /tmp/runtime /build-root /target-root
 
 # Download the target libs/headers required for compilation
 RUN <<EOF
-apt-get update
-apt-get install --reinstall --download-only -o=dir::cache=/tmp/devel -y -f \
+RUN apt-get update
+RUN apt-get install --reinstall --download-only -o=dir::cache=/tmp/devel -y -f \
     libglib2.0-dev:$UBUNTU_ARCH \
     libsystemd0:$UBUNTU_ARCH \
     libgrpc++-dev:$UBUNTU_ARCH \
@@ -39,18 +39,18 @@ apt-get install --reinstall --download-only -o=dir::cache=/tmp/devel -y -f \
     libssl-dev:$UBUNTU_ARCH \
     libcrypto++-dev:$UBUNTU_ARCH \
     libgcrypt20:$UBUNTU_ARCH
-EOF
+RUN <<EOF
 RUN for f in /tmp/devel/archives/*.deb; do dpkg -x $f /build-root; done
 RUN cp -r /build-root/lib/* /build-root/usr/lib/ && rm -rf /build-root/lib
 
 # Separate the target libs required during runtime
 RUN <<EOF
-apt-get update
-apt-get install --reinstall --download-only -o=dir::cache=/tmp/runtime -y -f \
+RUN apt-get update
+RUN apt-get install --reinstall --download-only -o=dir::cache=/tmp/runtime -y -f \
     libgrpc++:$UBUNTU_ARCH \
     '^libprotobuf([0-9]{1,2})$':${UBUNTU_ARCH} \
     libc-ares2:$UBUNTU_ARCH
-EOF
+RUN <<EOF
 RUN for f in /tmp/runtime/archives/*.deb; do dpkg -x $f /target-root; done
 RUN cp -r /target-root/lib/* /target-root/usr/lib/ && rm -rf /target-root/lib
 

--- a/object-detector-cpp/Dockerfile.model
+++ b/object-detector-cpp/Dockerfile.model
@@ -12,9 +12,9 @@ FROM arm64v8/ubuntu:${UBUNTU_VERSION} as local-aarch64
 FROM local-${ARCH} as local
 
 RUN <<EOF
-apt-get update
-apt-get install -y -f openssl
-EOF
+RUN apt-get update
+RUN apt-get install -y -f openssl
+RUN <<EOF
 
 # Generate TSL/SSL test certificate
 RUN openssl req -x509 -batch -subj '/CN=localhost' -days 10000 -newkey rsa:4096 -nodes -out server.pem -keyout server.key

--- a/parameter-api-cpp/Dockerfile
+++ b/parameter-api-cpp/Dockerfile
@@ -21,18 +21,18 @@ ENV http_proxy=${HTTP_PROXY}
 ENV https_proxy=${HTTP_PROXY}
 
 RUN <<EOF
-apt-get update
-apt-get install -y -f libglib2.0-dev libsystemd0 protobuf-compiler-grpc
-apt-get clean
-rm -rf /var/lib/apt/lists/*
-EOF
+RUN apt-get update
+RUN apt-get install -y -f libglib2.0-dev libsystemd0 protobuf-compiler-grpc
+RUN apt-get clean
+RUN rm -rf /var/lib/apt/lists/*
+RUN <<EOF
 
 RUN mkdir -p /tmp/devel /tmp/runtime /build-root /target-root
 
 # Download the target libs/headers required for compilation
 RUN <<EOF
-apt-get update
-apt-get install --reinstall --download-only -o=dir::cache=/tmp/devel -y -f \
+RUN apt-get update
+RUN apt-get install --reinstall --download-only -o=dir::cache=/tmp/devel -y -f \
     libglib2.0-dev:$UBUNTU_ARCH \
     libsystemd0:$UBUNTU_ARCH \
     libgrpc++-dev:$UBUNTU_ARCH \
@@ -42,18 +42,18 @@ apt-get install --reinstall --download-only -o=dir::cache=/tmp/devel -y -f \
     libssl-dev:$UBUNTU_ARCH \
     libcrypto++-dev:$UBUNTU_ARCH \
     libgcrypt20:$UBUNTU_ARCH
-EOF
+RUN <<EOF
 RUN for f in /tmp/devel/archives/*.deb; do dpkg -x $f /build-root; done
 RUN cp -r /build-root/lib/* /build-root/usr/lib/ && rm -rf /build-root/lib
 
 # Separate the target libs required during runtime
 RUN <<EOF
-apt-get update
-apt-get install --reinstall --download-only -o=dir::cache=/tmp/runtime -y -f \
+RUN apt-get update
+RUN apt-get install --reinstall --download-only -o=dir::cache=/tmp/runtime -y -f \
     libgrpc++:$UBUNTU_ARCH \
     '^libprotobuf([0-9]{1,2})$':${UBUNTU_ARCH} \
     libc-ares2:$UBUNTU_ARCH
-EOF
+RUN <<EOF
 RUN for f in /tmp/runtime/archives/*.deb; do dpkg -x $f /target-root; done
 RUN cp -r /target-root/lib/* /target-root/usr/lib/ && rm -rf /target-root/lib
 

--- a/parameter-api-python/Dockerfile
+++ b/parameter-api-python/Dockerfile
@@ -12,8 +12,8 @@ FROM arm64v8/ubuntu:${UBUNTU_VERSION} as runtime-image-aarch64
 FROM ${REPO}/acap-computer-vision-sdk:${SDK_VERSION}-${ARCH} AS cv-sdk
 
 RUN <<EOF
-apt-get update
-apt-get install -y --no-install-recommends \
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends \
     ca-certificates \
     git \
     libprotobuf-dev \
@@ -24,7 +24,7 @@ apt-get install -y --no-install-recommends \
     protobuf-compiler \
     protobuf-compiler-grpc \
     python3-grpcio
-EOF
+RUN <<EOF
 
 # Generate TSL/SSL test certificate
 RUN openssl req -x509 -batch -subj '/CN=localhost' -days 365 -newkey rsa:4096 -nodes -out server.pem -keyout server.key


### PR DESCRIPTION
### Describe your changes

I change Dockerfile code to be valid instructions syntax of docker

### Issue ticket number and link

1. **RUN** instruction before any bash commands
2. change **EOF** to **RUN <<EOF**

- Ref #(docker instructions) https://docs.docker.com/engine/reference/builder/

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
