### PR TITLE
Reorder build and run instructions

### DIFF
--- a/.github/workflows/hello-world-cross-compiled.yml
+++ b/.github/workflows/hello-world-cross-compiled.yml
@@ -31,4 +31,3 @@ jobs:
         run: |
           cd $EXNAME
           docker build --no-cache --build-arg ARCH=${{ matrix.arch }} --tag $imagetag .
-          docker image rm -f $imagetag

--- a/.github/workflows/hello-world.yml
+++ b/.github/workflows/hello-world.yml
@@ -31,4 +31,3 @@ jobs:
         run: |
           cd $EXNAME
           docker build --no-cache --build-arg ARCH=${{ matrix.arch }} --tag $imagetag .
-          docker image rm -f $imagetag

--- a/.github/workflows/minimal-ml-inference.yml
+++ b/.github/workflows/minimal-ml-inference.yml
@@ -37,5 +37,4 @@ jobs:
           cd $EXNAME
           docker run --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
           docker build --no-cache --build-arg CHIP=${{ matrix.chip }} --build-arg ARCH=${{ matrix.arch }} --tag $imagetag .
-          docker build . -f Dockerfile.model -t $modeltag --build-arg ARCH=${{ matrix.arch }}
-          docker image rm -f $imagetag
+          docker build --file Dockerfile.model --tag $modeltag --build-arg ARCH=${{ matrix.arch }} .

--- a/.github/workflows/object-detector-cpp.yml
+++ b/.github/workflows/object-detector-cpp.yml
@@ -37,5 +37,4 @@ jobs:
           cd $EXNAME
           docker run --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
           docker build --no-cache --build-arg CHIP=${{ matrix.chip }} --build-arg ARCH=${{ matrix.arch }} --tag $imagetag .
-          docker build . -f Dockerfile.model -t $modeltag --build-arg ARCH=${{ matrix.arch }}
-          docker image rm -f $imagetag
+          docker build . --file Dockerfile.model --tag $modeltag --build-arg ARCH=${{ matrix.arch }}

--- a/.github/workflows/object-detector-cpp.yml
+++ b/.github/workflows/object-detector-cpp.yml
@@ -37,4 +37,4 @@ jobs:
           cd $EXNAME
           docker run --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
           docker build --no-cache --build-arg CHIP=${{ matrix.chip }} --build-arg ARCH=${{ matrix.arch }} --tag $imagetag .
-          docker build . --file Dockerfile.model --tag $modeltag --build-arg ARCH=${{ matrix.arch }}
+          docker build --file Dockerfile.model --tag $modeltag --build-arg ARCH=${{ matrix.arch }} .

--- a/.github/workflows/object-detector-python.yml
+++ b/.github/workflows/object-detector-python.yml
@@ -36,5 +36,4 @@ jobs:
         run: |
           cd $EXNAME
           docker build --no-cache --build-arg CHIP=${{ matrix.chip }} --build-arg ARCH=${{ matrix.arch }} --tag $imagetag .
-          docker build . -f Dockerfile.model -t $modeltag --build-arg ARCH=${{ matrix.arch }}
-          docker image rm -f $imagetag
+          docker build . --file Dockerfile.model --tag $modeltag --build-arg ARCH=${{ matrix.arch }}

--- a/.github/workflows/object-detector-python.yml
+++ b/.github/workflows/object-detector-python.yml
@@ -36,4 +36,4 @@ jobs:
         run: |
           cd $EXNAME
           docker build --no-cache --build-arg CHIP=${{ matrix.chip }} --build-arg ARCH=${{ matrix.arch }} --tag $imagetag .
-          docker build . --file Dockerfile.model --tag $modeltag --build-arg ARCH=${{ matrix.arch }}
+          docker build --file Dockerfile.model --tag $modeltag --build-arg ARCH=${{ matrix.arch }} .

--- a/.github/workflows/opencv-image-capture-cpp.yml
+++ b/.github/workflows/opencv-image-capture-cpp.yml
@@ -31,4 +31,3 @@ jobs:
         run: |
           cd $EXNAME
           docker build --no-cache --build-arg ARCH=${{ matrix.arch }} --tag $imagetag .
-          docker image rm -f $imagetag

--- a/.github/workflows/opencv-qr-decoder-python.yml
+++ b/.github/workflows/opencv-qr-decoder-python.yml
@@ -31,4 +31,3 @@ jobs:
         run: |
           cd $EXNAME
           docker build --no-cache --build-arg ARCH=${{ matrix.arch }} --tag $imagetag .
-          docker image rm -f $imagetag

--- a/.github/workflows/parameter-api-cpp.yml
+++ b/.github/workflows/parameter-api-cpp.yml
@@ -31,4 +31,3 @@ jobs:
         run: |
           cd $EXNAME
           docker build --no-cache --build-arg ARCH=${{ matrix.arch }} --tag $imagetag .
-          docker image rm -f $imagetag

--- a/.github/workflows/parameter-api-python.yml
+++ b/.github/workflows/parameter-api-python.yml
@@ -31,4 +31,3 @@ jobs:
         run: |
           cd $EXNAME
           docker build --no-cache --build-arg ARCH=${{ matrix.arch }} --tag $imagetag .
-          docker image rm -f $imagetag

--- a/.github/workflows/pose-estimator-with-flask.yml
+++ b/.github/workflows/pose-estimator-with-flask.yml
@@ -38,4 +38,4 @@ jobs:
           cd $EXNAME
           docker run --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
           docker build --no-cache --build-arg CHIP=${{ matrix.chip }} --build-arg ARCH=${{ matrix.arch }} --tag $imagetag .
-          docker build . --file Dockerfile.model --tag $modeltag --build-arg ARCH=${{ matrix.arch }}
+          docker build --file Dockerfile.model --tag $modeltag --build-arg ARCH=${{ matrix.arch }} .

--- a/.github/workflows/pose-estimator-with-flask.yml
+++ b/.github/workflows/pose-estimator-with-flask.yml
@@ -38,5 +38,4 @@ jobs:
           cd $EXNAME
           docker run --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
           docker build --no-cache --build-arg CHIP=${{ matrix.chip }} --build-arg ARCH=${{ matrix.arch }} --tag $imagetag .
-          docker build . -f Dockerfile.model -t $modeltag --build-arg ARCH=${{ matrix.arch }}
-          docker image rm -f $imagetag
+          docker build . --file Dockerfile.model --tag $modeltag --build-arg ARCH=${{ matrix.arch }}

--- a/.github/workflows/web-server.yml
+++ b/.github/workflows/web-server.yml
@@ -32,4 +32,3 @@ jobs:
           cd $EXNAME
           docker run --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
           docker build --no-cache --build-arg ARCH=${{ matrix.arch }} --tag $imagetag .
-          docker image rm -f $imagetag

--- a/hello-world-cross-compiled/README.md
+++ b/hello-world-cross-compiled/README.md
@@ -66,7 +66,7 @@ docker build --tag $APP_NAME --build-arg ARCH .
 DEVICE_IP=<actual camera IP address>
 DOCKER_PORT=2376
 
-docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT system prune --all --force
 ```
 
 If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap).
@@ -76,7 +76,7 @@ If you encounter any TLS related issues, please see the TLS setup chapter regard
 Next, the built image needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
 
 ```sh
-docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
+docker save $APP_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT load
 ```
 
 ### Run the container
@@ -84,10 +84,10 @@ docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 With the application image on the device, it can be started. As the example uses OpenCV, the OpenCV requirements will be included in `docker-compose.yml`, which is used to run the application:
 
 ```sh
-docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT up
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT up
 
 # Terminate with Ctrl-C and cleanup
-docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT down -v
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT down -v
 ```
 
 The expected output from the application is (depending on the OpenCV pulled from the ACAP Computer Vision SDK):

--- a/hello-world-cross-compiled/README.md
+++ b/hello-world-cross-compiled/README.md
@@ -54,7 +54,7 @@ With the architecture defined, the `hello-world-cross-compiled` image can be bui
 
 ```sh
 # Define app name
-APP_NAME=hello-world-cross-compiled
+export APP_NAME=hello-world-cross-compiled
 
 # Build
 docker build --tag $APP_NAME --build-arg ARCH .

--- a/hello-world-cross-compiled/README.md
+++ b/hello-world-cross-compiled/README.md
@@ -38,36 +38,40 @@ Meet the following requirements to ensure compatibility with the example:
 
 ### Export the environment variable for the architecture
 
-Export the ARCH variable depending on the architecture of your camera
+Export the `ARCH` variable depending on the architecture of your camera:
 
 ```sh
 # For arm32
 export ARCH=armv7hf
+
 # For arm64
 export ARCH=aarch64
 ```
 
-### Set your camera IP address define APP name and clear Docker memory
+### Build the Docker image
+
+With the architecture defined, the `hello-world-cross-compiled` image can be built. The environment variables are supplied as build arguments such that they are made available to docker during the build process:
 
 ```sh
-# Set camera IP
+# Define app name
+APP_NAME=hello-world-cross-compiled
+
+# Build
+docker build --tag $APP_NAME --build-arg ARCH .
+```
+
+### Set your device IP address and clear Docker memory
+
+```sh
 DEVICE_IP=<actual camera IP address>
 DOCKER_PORT=2376
 
-# Define APP name
-APP_NAME=hello-world-cross-compiled
-
-# Clean docker memory
 docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
 ```
 
-### Build and run the images
+If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap).
 
-With the environment setup, the `hello-world-cross-compiled` image can be built. The environment variables are supplied as build arguments such that they are made available to docker during the build process:
-
-```sh
-docker build --tag $APP_NAME --build-arg ARCH .
-```
+### Install the image
 
 Next, the built image needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
 
@@ -75,18 +79,20 @@ Next, the built image needs to be uploaded to the device. This can be done throu
 docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 ```
 
+### Run the container
+
 With the application image on the device, it can be started. As the example uses OpenCV, the OpenCV requirements will be included in `docker-compose.yml`, which is used to run the application:
 
 ```sh
 docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT up
 
-# Cleanup after execution
+# Terminate with Ctrl-C and cleanup
 docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT down -v
 ```
 
 The expected output from the application is (depending on the OpenCV pulled from the ACAP Computer Vision SDK):
 
-```sh
+```text
 ...
 Hello World from OpenCV 4.5.1
 ```

--- a/hello-world-cross-compiled/README.md
+++ b/hello-world-cross-compiled/README.md
@@ -86,7 +86,7 @@ With the application image on the device, it can be started. As the example uses
 ```sh
 docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT up
 
-# Terminate with Ctrl-C and cleanup
+# Cleanup
 docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT down --volumes
 ```
 

--- a/hello-world-cross-compiled/README.md
+++ b/hello-world-cross-compiled/README.md
@@ -66,7 +66,7 @@ docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
 With the environment setup, the `hello-world-cross-compiled` image can be built. The environment variables are supplied as build arguments such that they are made available to docker during the build process:
 
 ```sh
-docker build . -t $APP_NAME --build-arg ARCH
+docker build . --tag $APP_NAME --build-arg ARCH
 ```
 
 Next, the built image needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:

--- a/hello-world-cross-compiled/README.md
+++ b/hello-world-cross-compiled/README.md
@@ -66,7 +66,7 @@ docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
 With the environment setup, the `hello-world-cross-compiled` image can be built. The environment variables are supplied as build arguments such that they are made available to docker during the build process:
 
 ```sh
-docker build . --tag $APP_NAME --build-arg ARCH
+docker build --tag $APP_NAME --build-arg ARCH .
 ```
 
 Next, the built image needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:

--- a/hello-world-cross-compiled/README.md
+++ b/hello-world-cross-compiled/README.md
@@ -87,7 +87,7 @@ With the application image on the device, it can be started. As the example uses
 docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT up
 
 # Terminate with Ctrl-C and cleanup
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT down -v
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT down --volumes
 ```
 
 The expected output from the application is (depending on the OpenCV pulled from the ACAP Computer Vision SDK):

--- a/hello-world/README.md
+++ b/hello-world/README.md
@@ -54,7 +54,7 @@ With the architecture defined, the `hello-world` image can be built. The environ
 
 ```sh
 # Define app name
-APP_NAME=hello-world
+export APP_NAME=hello-world
 
 docker build --tag $APP_NAME --build-arg ARCH .
 ```

--- a/hello-world/README.md
+++ b/hello-world/README.md
@@ -66,7 +66,7 @@ docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
 With the environment setup, the `hello-world` image can be built. The environment variables are supplied as build arguments such that they are made available to docker during the build process:
 
 ```sh
-docker build . --tag $APP_NAME --build-arg ARCH
+docker build --tag $APP_NAME --build-arg ARCH .
 ```
 
 Next, the built image needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:

--- a/hello-world/README.md
+++ b/hello-world/README.md
@@ -38,7 +38,7 @@ Meet the following requirements to ensure compatibility with the example:
 
 ### Export the environment variable for the architecture
 
-Export the ARCH variable depending on the architecture of your camera
+Export the `ARCH` variable depending on the architecture of your camera:
 
 ```sh
 # For arm32
@@ -47,27 +47,29 @@ export ARCH=armv7hf
 export ARCH=aarch64
 ```
 
-### Set your camera IP address define APP name and clear Docker memory
+### Build the Docker image
+
+With the architecture defined, the `hello-world` image can be built. The environment variables are supplied as build arguments such that they are made available to docker during the build process:
 
 ```sh
-# Set camera IP
+# Define app name
+APP_NAME=hello-world
+
+docker build --tag $APP_NAME --build-arg ARCH .
+```
+
+### Set your device IP address and clear Docker memory
+
+```sh
 DEVICE_IP=<actual camera IP address>
 DOCKER_PORT=2376
 
-# Define APP name
-APP_NAME=hello-world
-
-# Clean docker memory
 docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
 ```
 
-### Build and run the images
+If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap).
 
-With the environment setup, the `hello-world` image can be built. The environment variables are supplied as build arguments such that they are made available to docker during the build process:
-
-```sh
-docker build --tag $APP_NAME --build-arg ARCH .
-```
+### Install the image
 
 Next, the built image needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
 
@@ -75,18 +77,20 @@ Next, the built image needs to be uploaded to the device. This can be done throu
 docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 ```
 
-With the application image on the device, it can be started. As this example does not use e.g., OpenCV, no special mounts are needed, making the `docker-compose.yml` file very simple:
+### Run the container
+
+With the application image on the device, it can be started using `docker-compose.yml`:
 
 ```sh
 docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT up
 
-# Cleanup after execution
+# Terminate with Ctrl-C and cleanup
 docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT down -v
 ```
 
 The expected output from the application is simply:
 
-```sh
+```text
 Hello World!
 ```
 

--- a/hello-world/README.md
+++ b/hello-world/README.md
@@ -43,6 +43,7 @@ Export the `ARCH` variable depending on the architecture of your camera:
 ```sh
 # For arm32
 export ARCH=armv7hf
+
 # For arm64
 export ARCH=aarch64
 ```

--- a/hello-world/README.md
+++ b/hello-world/README.md
@@ -64,7 +64,7 @@ docker build --tag $APP_NAME --build-arg ARCH .
 DEVICE_IP=<actual camera IP address>
 DOCKER_PORT=2376
 
-docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT system prune --all --force
 ```
 
 If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap).
@@ -74,7 +74,7 @@ If you encounter any TLS related issues, please see the TLS setup chapter regard
 Next, the built image needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
 
 ```sh
-docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
+docker save $APP_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT load
 ```
 
 ### Run the container
@@ -82,10 +82,10 @@ docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 With the application image on the device, it can be started using `docker-compose.yml`:
 
 ```sh
-docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT up
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT up
 
 # Terminate with Ctrl-C and cleanup
-docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT down -v
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT down -v
 ```
 
 The expected output from the application is simply:

--- a/hello-world/README.md
+++ b/hello-world/README.md
@@ -85,7 +85,7 @@ With the application image on the device, it can be started using `docker-compos
 ```sh
 docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT up
 
-# Terminate with Ctrl-C and cleanup
+# Cleanup
 docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT down
 ```
 

--- a/hello-world/README.md
+++ b/hello-world/README.md
@@ -66,7 +66,7 @@ docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
 With the environment setup, the `hello-world` image can be built. The environment variables are supplied as build arguments such that they are made available to docker during the build process:
 
 ```sh
-docker build . -t $APP_NAME --build-arg ARCH
+docker build . --tag $APP_NAME --build-arg ARCH
 ```
 
 Next, the built image needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:

--- a/hello-world/README.md
+++ b/hello-world/README.md
@@ -85,7 +85,7 @@ With the application image on the device, it can be started using `docker-compos
 docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT up
 
 # Terminate with Ctrl-C and cleanup
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT down -v
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT down
 ```
 
 The expected output from the application is simply:

--- a/minimal-ml-inference/README.md
+++ b/minimal-ml-inference/README.md
@@ -67,7 +67,7 @@ With the architecture defined, the `acap4-minimal-ml-inference` and `acap-dl-mod
 
 ```sh
 # Define app name
-APP_NAME=acap4-minimal-ml-inference
+export APP_NAME=acap4-minimal-ml-inference
 MODEL_NAME=acap-dl-models
 
 # Install qemu to allow build flask for a different architecture

--- a/minimal-ml-inference/README.md
+++ b/minimal-ml-inference/README.md
@@ -68,7 +68,7 @@ With the architecture defined, the `acap4-minimal-ml-inference` and `acap-dl-mod
 ```sh
 # Define app name
 export APP_NAME=acap4-minimal-ml-inference
-MODEL_NAME=acap-dl-models
+export MODEL_NAME=acap-dl-models
 
 # Install qemu to allow build flask for a different architecture
 docker run --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
@@ -116,9 +116,8 @@ The expected output from the application is the raw predictions from the model s
 
 ### Hardware acceleration
 
-The ./config folder contains configuration files with the parameters to run the inference on different camera models, also giving the possibility to use the hardware accelerator.
-To achieve the best performance we recommend using the TPU (Tensor Processing Unit) equipped with artpec7 cameras (e.g. [Axis-Q1615 Mk III](https://www.axis.com/products/axis-q1615-mk-iii))
-or the DLPU (Deep Learning Processing Unit) equipped in artpec8 cameras (e.g. [Axis-Q1656](https://www.axis.com/products/axis-q1656))
+The `./config` folder contains configuration files with the parameters to run the inference on different camera models, also giving the possibility to use the hardware accelerator. To achieve the best performance we recommend using the TPU (Tensor Processing Unit) equipped with ARTPEC-7 cameras (e.g. [Axis-Q1615 Mk III](https://www.axis.com/products/axis-q1615-mk-iii))
+or the DLPU (Deep Learning Processing Unit) equipped in ARTPEC-8 cameras (e.g. [Axis-Q1656](https://www.axis.com/products/axis-q1656)).
 
 ## License
 

--- a/minimal-ml-inference/README.md
+++ b/minimal-ml-inference/README.md
@@ -78,11 +78,11 @@ MODEL_NAME=acap-dl-models
 docker run -it --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
 
 # Build and upload inference client for camera
-docker build . --tag $APP_NAME --build-arg ARCH
+docker build --tag $APP_NAME --build-arg ARCH .
 docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 
 # Build and upload inference models
-docker build . --file Dockerfile.model --tag $MODEL_NAME --build-arg ARCH
+docker build --file Dockerfile.model --tag $MODEL_NAME --build-arg ARCH .
 docker save $MODEL_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 
 # Use the following command to run the example on the camera

--- a/minimal-ml-inference/README.md
+++ b/minimal-ml-inference/README.md
@@ -86,7 +86,7 @@ docker build --file Dockerfile.model --tag $MODEL_NAME --build-arg ARCH .
 DEVICE_IP=<actual camera IP address>
 DOCKER_PORT=2376
 
-docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT system prune --all --force
 ```
 
 If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap).
@@ -96,9 +96,9 @@ If you encounter any TLS related issues, please see the TLS setup chapter regard
 Next, the built images needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
 
 ```sh
-docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
+docker save $APP_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT load
 
-docker save $MODEL_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
+docker save $MODEL_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT load
 ```
 
 ### Run the containers
@@ -106,10 +106,10 @@ docker save $MODEL_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT lo
 With the application image on the device, it can be started using `docker-compose.yml`:
 
 ```sh
-docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP up
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP up
 
 # Terminate with Ctrl-C and cleanup
-docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP down -v
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP down -v
 ```
 
 The expected output from the application is the raw predictions from the model specified in the environment variable.

--- a/minimal-ml-inference/README.md
+++ b/minimal-ml-inference/README.md
@@ -109,7 +109,7 @@ With the application image on the device, it can be started using `docker-compos
 docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP up
 
 # Terminate with Ctrl-C and cleanup
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP down -v
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP down --volumes
 ```
 
 The expected output from the application is the raw predictions from the model specified in the environment variable.

--- a/minimal-ml-inference/README.md
+++ b/minimal-ml-inference/README.md
@@ -71,7 +71,7 @@ APP_NAME=acap4-minimal-ml-inference
 MODEL_NAME=acap-dl-models
 
 # Install qemu to allow build flask for a different architecture
-docker run -it --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
+docker run --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
 
 # Build app
 docker build --tag $APP_NAME --build-arg ARCH .

--- a/minimal-ml-inference/README.md
+++ b/minimal-ml-inference/README.md
@@ -78,11 +78,11 @@ MODEL_NAME=acap-dl-models
 docker run -it --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
 
 # Build and upload inference client for camera
-docker build . -t $APP_NAME --build-arg ARCH
+docker build . --tag $APP_NAME --build-arg ARCH
 docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 
 # Build and upload inference models
-docker build . -f Dockerfile.model -t $MODEL_NAME --build-arg ARCH
+docker build . --file Dockerfile.model --tag $MODEL_NAME --build-arg ARCH
 docker save $MODEL_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 
 # Use the following command to run the example on the camera

--- a/minimal-ml-inference/README.md
+++ b/minimal-ml-inference/README.md
@@ -43,11 +43,12 @@ Meet the following requirements to ensure compatibility with the example:
 
 ### Export the environment variable for the architecture
 
-Export the ARCH variable depending on the architecture of your camera
+Export the `ARCH` variable depending on the architecture of your camera:
 
 ```sh
 # For arm32
 export ARCH=armv7hf
+
 # Valid options for chip on armv7hf are 'tpu' (hardware accelerator) or 'cpu'
 export CHIP=tpu
 ```
@@ -55,37 +56,56 @@ export CHIP=tpu
 ```sh
 # For arm64
 export ARCH=aarch64
+
 # Valid options for chip on aarch64 are 'artpec8' (hardware accelerator) or 'cpu'
 export CHIP=artpec8
 ```
 
-### Set your camera IP address and clear Docker memory
+### Build the Docker images
+
+With the architecture defined, the `acap4-minimal-ml-inference` and `acap-dl-models` images can be built. The environment variables are supplied as build arguments such that they are made available to docker during the build process:
 
 ```sh
-DEVICE_IP=<actual camera IP address>
-DOCKER_PORT=2376
-docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
-```
-
-### Build the minimal-ml-inference images
-
-```sh
-# Define APP name
+# Define app name
 APP_NAME=acap4-minimal-ml-inference
 MODEL_NAME=acap-dl-models
 
 # Install qemu to allow build flask for a different architecture
 docker run -it --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
 
-# Build and upload inference client for camera
+# Build app
 docker build --tag $APP_NAME --build-arg ARCH .
+
+# Build inference model
+docker build --file Dockerfile.model --tag $MODEL_NAME --build-arg ARCH .
+```
+
+### Set your device IP address and clear Docker memory
+
+```sh
+DEVICE_IP=<actual camera IP address>
+DOCKER_PORT=2376
+
+docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
+```
+
+If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap).
+
+### Install the images
+
+Next, the built images needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
+
+```sh
 docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 
-# Build and upload inference models
-docker build --file Dockerfile.model --tag $MODEL_NAME --build-arg ARCH .
 docker save $MODEL_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
+```
 
-# Use the following command to run the example on the camera
+### Run the containers
+
+With the application image on the device, it can be started using `docker-compose.yml`:
+
+```sh
 docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP up
 
 # Terminate with Ctrl-C and cleanup

--- a/minimal-ml-inference/README.md
+++ b/minimal-ml-inference/README.md
@@ -116,8 +116,7 @@ The expected output from the application is the raw predictions from the model s
 
 ### Hardware acceleration
 
-The `./config` folder contains configuration files with the parameters to run the inference on different camera models, also giving the possibility to use the hardware accelerator. To achieve the best performance we recommend using the TPU (Tensor Processing Unit) equipped with ARTPEC-7 cameras (e.g. [Axis-Q1615 Mk III](https://www.axis.com/products/axis-q1615-mk-iii))
-or the DLPU (Deep Learning Processing Unit) equipped in ARTPEC-8 cameras (e.g. [Axis-Q1656](https://www.axis.com/products/axis-q1656)).
+The `./config` folder contains configuration files with the parameters to run the inference on different camera models, also giving the possibility to use the hardware accelerator. To achieve the best performance we recommend using the TPU (Tensor Processing Unit) equipped with ARTPEC-7 cameras (e.g. [Axis-Q1615 Mk III](https://www.axis.com/products/axis-q1615-mk-iii)) or the DLPU (Deep Learning Processing Unit) equipped in ARTPEC-8 cameras (e.g. [Axis-Q1656](https://www.axis.com/products/axis-q1656)).
 
 ## License
 

--- a/object-detector-cpp/README.md
+++ b/object-detector-cpp/README.md
@@ -80,7 +80,7 @@ APP_NAME=acap4-object-detector-cpp
 MODEL_NAME=acap-dl-models
 
 # Install qemu to allow build flask for a different architecture
-docker run -it --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
+docker run --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
 
 # Build app
 docker build --tag $APP_NAME --build-arg ARCH .

--- a/object-detector-cpp/README.md
+++ b/object-detector-cpp/README.md
@@ -72,7 +72,7 @@ export CHIP=artpec8
 
 ### Build the Docker images
 
-With the architecture defined, the `acap4-object-detector-cpp` image can be built. The environment variables are supplied as build arguments such that they are made available to docker during the build process:
+With the architecture defined, the `acap4-object-detector-cpp` and `acap-dl-models` images can be built. The environment variables are supplied as build arguments such that they are made available to docker during the build process:
 
 ```sh
 # Define app name

--- a/object-detector-cpp/README.md
+++ b/object-detector-cpp/README.md
@@ -87,11 +87,11 @@ MODEL_NAME=acap-dl-models
 docker run -it --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
 
 # Build and upload inference client for camera
-docker build . -t $APP_NAME --build-arg ARCH
+docker build . --tag $APP_NAME --build-arg ARCH
 docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 
 # Build and upload inference models
-docker build . -f Dockerfile.model -t $MODEL_NAME --build-arg ARCH
+docker build . --file Dockerfile.model --tag $MODEL_NAME --build-arg ARCH
 docker save $MODEL_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 
 # Use the following command to run the example on the camera

--- a/object-detector-cpp/README.md
+++ b/object-detector-cpp/README.md
@@ -76,7 +76,7 @@ With the architecture defined, the `acap4-object-detector-cpp` image can be buil
 
 ```sh
 # Define app name
-APP_NAME=acap4-object-detector-cpp
+export APP_NAME=acap4-object-detector-cpp
 MODEL_NAME=acap-dl-models
 
 # Install qemu to allow build flask for a different architecture

--- a/object-detector-cpp/README.md
+++ b/object-detector-cpp/README.md
@@ -112,7 +112,7 @@ docker save $MODEL_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_POR
 
 ### Run the containers
 
-With the application image on the device, it can be started using `docker-compose.yml`:
+With the images on the device, they can be started using `docker-compose.yml`:
 
 ```sh
 docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP up

--- a/object-detector-cpp/README.md
+++ b/object-detector-cpp/README.md
@@ -70,7 +70,7 @@ export ARCH=aarch64
 export CHIP=artpec8
 ```
 
-### Build the Docker image
+### Build the Docker images
 
 With the architecture defined, the `acap4-object-detector-cpp` image can be built. The environment variables are supplied as build arguments such that they are made available to docker during the build process:
 

--- a/object-detector-cpp/README.md
+++ b/object-detector-cpp/README.md
@@ -87,11 +87,11 @@ MODEL_NAME=acap-dl-models
 docker run -it --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
 
 # Build and upload inference client for camera
-docker build . --tag $APP_NAME --build-arg ARCH
+docker build --tag $APP_NAME --build-arg ARCH .
 docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 
 # Build and upload inference models
-docker build . --file Dockerfile.model --tag $MODEL_NAME --build-arg ARCH
+docker build --file Dockerfile.model --tag $MODEL_NAME --build-arg ARCH .
 docker save $MODEL_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 
 # Use the following command to run the example on the camera

--- a/object-detector-cpp/README.md
+++ b/object-detector-cpp/README.md
@@ -77,7 +77,7 @@ With the architecture defined, the `acap4-object-detector-cpp` image can be buil
 ```sh
 # Define app name
 export APP_NAME=acap4-object-detector-cpp
-MODEL_NAME=acap-dl-models
+export MODEL_NAME=acap-dl-models
 
 # Install qemu to allow build flask for a different architecture
 docker run --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
@@ -110,7 +110,7 @@ docker save $APP_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT 
 docker save $MODEL_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT load
 ```
 
-### Run the container
+### Run the containers
 
 With the application image on the device, it can be started using `docker-compose.yml`:
 
@@ -142,7 +142,7 @@ For reference please see: https://docs.docker.com/network/proxy/.
 
 ## Zero copy
 
-This example uses larod-inference-server for video inference processing by using gRPC API. In case this client and the inference server is located on the same camera, it is possible to speed up inference by using shared memory to pass the video image to the inference server by activating following define statement in file src/serving_client.hpp:
+This example uses larod-inference-server for video inference processing by using gRPC API. In case this client and the inference server is located on the same camera, it is possible to speed up inference by using shared memory to pass the video image to the inference server by activating following define statement in file `app/src/serving_client.hpp`:
 
 ```c++
 #define ZEROCOPY
@@ -168,9 +168,7 @@ This example uses larod-inference-server for video inference processing by using
 
 ### Hardware acceleration
 
-The ./config folder contains configuration files with the parameters to run the inference on different camera models, also giving the possibility to use the hardware accelerator.
-To achieve the best performance we recommend using the TPU (Tensor Processing Unit) equipped with artpec7 cameras (e.g. [Axis-Q1615 Mk III](https://www.axis.com/products/axis-q1615-mk-iii))
-or the DLPU (Deep Learning Processing Unit) equipped in artpec8 cameras (e.g. [Axis-Q1656](https://www.axis.com/products/axis-q1656))
+The `./config` folder contains configuration files with the parameters to run the inference on different camera models, also giving the possibility to use the hardware accelerator. To achieve the best performance we recommend using the TPU (Tensor Processing Unit) equipped with ARTPEC-7 cameras (e.g. [Axis-Q1615 Mk III](https://www.axis.com/products/axis-q1615-mk-iii)) or the DLPU (Deep Learning Processing Unit) equipped in ARTPEC-8 cameras (e.g. [Axis-Q1656](https://www.axis.com/products/axis-q1656)).
 
 ## License
 

--- a/object-detector-cpp/README.md
+++ b/object-detector-cpp/README.md
@@ -118,7 +118,7 @@ With the application image on the device, it can be started using `docker-compos
 docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP up
 
 # Terminate with Ctrl-C and cleanup
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP down -v
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP down --volumes
 ```
 
 ### The expected output

--- a/object-detector-cpp/README.md
+++ b/object-detector-cpp/README.md
@@ -95,7 +95,7 @@ docker build --file Dockerfile.model --tag $MODEL_NAME --build-arg ARCH .
 DEVICE_IP=<actual camera IP address>
 DOCKER_PORT=2376
 
-docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT system prune --all --force
 ```
 
 If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap).
@@ -105,9 +105,9 @@ If you encounter any TLS related issues, please see the TLS setup chapter regard
 Next, the built images needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
 
 ```sh
-docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
+docker save $APP_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT load
 
-docker save $MODEL_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
+docker save $MODEL_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT load
 ```
 
 ### Run the container
@@ -115,10 +115,10 @@ docker save $MODEL_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT lo
 With the application image on the device, it can be started using `docker-compose.yml`:
 
 ```sh
-docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP up
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP up
 
 # Terminate with Ctrl-C and cleanup
-docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP down -v
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP down -v
 ```
 
 ### The expected output

--- a/object-detector-python/README.md
+++ b/object-detector-python/README.md
@@ -94,7 +94,7 @@ APP_NAME=acap4-object-detector-python
 MODEL_NAME=acap-dl-models
 
 # Install qemu to allow build flask for a different architecture
-docker run -it --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
+docker run --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
 
 # Build app
 docker build --tag $APP_NAME --build-arg ARCH .

--- a/object-detector-python/README.md
+++ b/object-detector-python/README.md
@@ -101,11 +101,11 @@ MODEL_NAME=acap-dl-models
 docker run -it --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
 
 # Build and upload inference client for camera
-docker build . --tag $APP_NAME --build-arg ARCH
+docker build --tag $APP_NAME --build-arg ARCH .
 docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 
 # Build and upload inference models
-docker build . --file Dockerfile.model --tag $MODEL_NAME --build-arg ARCH
+docker build --file Dockerfile.model --tag $MODEL_NAME --build-arg ARCH .
 docker save $MODEL_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 
 # Use the following command to run the example on the camera

--- a/object-detector-python/README.md
+++ b/object-detector-python/README.md
@@ -101,11 +101,11 @@ MODEL_NAME=acap-dl-models
 docker run -it --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
 
 # Build and upload inference client for camera
-docker build . -t $APP_NAME --build-arg ARCH
+docker build . --tag $APP_NAME --build-arg ARCH
 docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 
 # Build and upload inference models
-docker build . -f Dockerfile.model -t $MODEL_NAME --build-arg ARCH
+docker build . --file Dockerfile.model --tag $MODEL_NAME --build-arg ARCH
 docker save $MODEL_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 
 # Use the following command to run the example on the camera
@@ -125,7 +125,7 @@ object-detector_1           | person
 ```
 
 ```sh
-docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT -f static-image.yml --env-file ./config/env.$ARCH.$CHIP up
+docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT --file static-image.yml --env-file ./config/env.$ARCH.$CHIP up
 ....
 object-detector-python_1          | 3 Objects found
 object-detector-python_1          | bicycle

--- a/object-detector-python/README.md
+++ b/object-detector-python/README.md
@@ -90,7 +90,7 @@ With the architecture defined, the `acap4-object-detector-python` and `acap-dl-m
 
 ```sh
 # Define app name
-APP_NAME=acap4-object-detector-python
+export APP_NAME=acap4-object-detector-python
 MODEL_NAME=acap-dl-models
 
 # Install qemu to allow build flask for a different architecture

--- a/object-detector-python/README.md
+++ b/object-detector-python/README.md
@@ -91,7 +91,7 @@ With the architecture defined, the `acap4-object-detector-python` and `acap-dl-m
 ```sh
 # Define app name
 export APP_NAME=acap4-object-detector-python
-MODEL_NAME=acap-dl-models
+export MODEL_NAME=acap-dl-models
 
 # Install qemu to allow build flask for a different architecture
 docker run --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
@@ -155,9 +155,7 @@ object-detector-python_1          | car
 
 ### Hardware acceleration
 
-The ./config folder contains configuration files with the parameters to run the inference on different camera models, also giving the possibility to use the hardware accelerator.
-To achieve the best performance we recommend using the TPU (Tensor Processing Unit) equipped with artpec7 cameras (e.g. [Axis-Q1615 Mk III](https://www.axis.com/products/axis-q1615-mk-iii))
-or the DLPU (Deep Learning Processing Unit) equipped in artpec8 cameras (e.g. [Axis-Q1656](https://www.axis.com/products/axis-q1656))
+The `./config` folder contains configuration files with the parameters to run the inference on different camera models, also giving the possibility to use the hardware accelerator. To achieve the best performance we recommend using the TPU (Tensor Processing Unit) equipped with ARTPEC-7 cameras (e.g. [Axis-Q1615 Mk III](https://www.axis.com/products/axis-q1615-mk-iii)) or the DLPU (Deep Learning Processing Unit) equipped in ARTPEC-8 cameras (e.g. [Axis-Q1656](https://www.axis.com/products/axis-q1656)).
 
 ## License
 

--- a/object-detector-python/README.md
+++ b/object-detector-python/README.md
@@ -132,7 +132,7 @@ With the application image on the device, it can be started using `docker-compos
 docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP up
 
 # Terminate with Ctrl-C and cleanup
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP down -v
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP down --volumes
 ```
 
 ### The expected output

--- a/object-detector-python/README.md
+++ b/object-detector-python/README.md
@@ -109,7 +109,7 @@ docker build --file Dockerfile.model --tag $MODEL_NAME --build-arg ARCH .
 DEVICE_IP=<actual camera IP address>
 DOCKER_PORT=2376
 
-docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT system prune --all --force
 ```
 
 If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap).
@@ -119,9 +119,9 @@ If you encounter any TLS related issues, please see the TLS setup chapter regard
 Next, the built images needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
 
 ```sh
-docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
+docker save $APP_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT load
 
-docker save $MODEL_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
+docker save $MODEL_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT load
 ```
 
 ### Run the containers
@@ -129,23 +129,23 @@ docker save $MODEL_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT lo
 With the application image on the device, it can be started using `docker-compose.yml`:
 
 ```sh
-docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP up
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP up
 
 # Terminate with Ctrl-C and cleanup
-docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP down -v
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP down -v
 ```
 
 ### The expected output
 
 ```sh
-docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP up
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP up
 ....
 object-detector_1           | 1 Objects found
 object-detector_1           | person
 ```
 
 ```sh
-docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT --file static-image.yml --env-file ./config/env.$ARCH.$CHIP up
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --file static-image.yml --env-file ./config/env.$ARCH.$CHIP up
 ....
 object-detector-python_1          | 3 Objects found
 object-detector-python_1          | bicycle

--- a/object-detector-python/README.md
+++ b/object-detector-python/README.md
@@ -66,11 +66,12 @@ Meet the following requirements to ensure compatibility with the example:
 
 ### Export the environment variable for the architecture
 
-Export the ARCH variable depending on the architecture of your camera
+Export the `ARCH` variable depending on the architecture of your camera:
 
 ```sh
 # For arm32
 export ARCH=armv7hf
+
 # Valid options for chip on armv7hf are 'tpu' (hardware accelerator) or 'cpu'
 export CHIP=tpu
 ```
@@ -78,37 +79,56 @@ export CHIP=tpu
 ```sh
 # For arm64
 export ARCH=aarch64
+
 # Valid options for chip on aarch64 are 'artpec8' (hardware accelerator) or 'cpu'
 export CHIP=artpec8
 ```
 
-### Set your camera IP address and clear Docker memory
+### Build the Docker images
+
+With the architecture defined, the `acap4-object-detector-python` and `acap-dl-models` images can be built. The environment variables are supplied as build arguments such that they are made available to docker during the build process:
 
 ```sh
-DEVICE_IP=<actual camera IP address>
-DOCKER_PORT=2376
-docker -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
-```
-
-### Build the object-detector-python images
-
-```sh
-# Define APP name
+# Define app name
 APP_NAME=acap4-object-detector-python
 MODEL_NAME=acap-dl-models
 
 # Install qemu to allow build flask for a different architecture
 docker run -it --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
 
-# Build and upload inference client for camera
+# Build app
 docker build --tag $APP_NAME --build-arg ARCH .
+
+# Build inference model
+docker build --file Dockerfile.model --tag $MODEL_NAME --build-arg ARCH .
+```
+
+### Set your device IP address and clear Docker memory
+
+```sh
+DEVICE_IP=<actual camera IP address>
+DOCKER_PORT=2376
+
+docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
+```
+
+If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap).
+
+### Install the images
+
+Next, the built images needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
+
+```sh
 docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 
-# Build and upload inference models
-docker build --file Dockerfile.model --tag $MODEL_NAME --build-arg ARCH .
 docker save $MODEL_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
+```
 
-# Use the following command to run the example on the camera
+### Run the containers
+
+With the application image on the device, it can be started using `docker-compose.yml`:
+
+```sh
 docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP up
 
 # Terminate with Ctrl-C and cleanup

--- a/opencv-image-capture-cpp/README.md
+++ b/opencv-image-capture-cpp/README.md
@@ -83,7 +83,7 @@ docker build --tag $APP_NAME --build-arg ARCH .
 DEVICE_IP=<actual camera IP address>
 DOCKER_PORT=2376
 
-docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT system prune --all --force
 ```
 
 If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap).
@@ -93,7 +93,7 @@ If you encounter any TLS related issues, please see the TLS setup chapter regard
 Next, the built image needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
 
 ```sh
-docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
+docker save $APP_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT load
 ```
 
 ### Run the container
@@ -101,10 +101,10 @@ docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 With the application image on the device, it can be started using `docker-compose.yml`:
 
 ```sh
-docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT --file docker-compose.yml up
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --file docker-compose.yml up
 
 # Terminate with Ctrl-C and cleanup
-docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT --file docker-compose.yml down -v
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --file docker-compose.yml down -v
 ```
 
 #### The expected output

--- a/opencv-image-capture-cpp/README.md
+++ b/opencv-image-capture-cpp/README.md
@@ -88,7 +88,7 @@ docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT system prune --all --for
 
 If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap).
 
-### Install the images
+### Install the image
 
 Next, the built image needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
 
@@ -101,10 +101,10 @@ docker save $APP_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT 
 With the application image on the device, it can be started using `docker-compose.yml`:
 
 ```sh
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --file docker-compose.yml up
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT up
 
 # Terminate with Ctrl-C and cleanup
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --file docker-compose.yml down --volumes
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT down --volumes
 ```
 
 #### The expected output

--- a/opencv-image-capture-cpp/README.md
+++ b/opencv-image-capture-cpp/README.md
@@ -72,7 +72,7 @@ With the architecture defined, the `acap-opencv-image-capture-cpp` image can be 
 
 ```sh
 # Define app name
-APP_NAME=acap-opencv-image-capture-cpp
+export APP_NAME=acap-opencv-image-capture-cpp
 
 docker build --tag $APP_NAME --build-arg ARCH .
 ```

--- a/opencv-image-capture-cpp/README.md
+++ b/opencv-image-capture-cpp/README.md
@@ -56,38 +56,54 @@ opencv-image-capture-cpp
 
 ### Export the environment variable for the architecture
 
-Export the ARCH variable depending on the architecture of your camera
+Export the `ARCH` variable depending on the architecture of your camera:
 
 ```sh
 # For arm32
 export ARCH=armv7hf
+
 # For arm64
 export ARCH=aarch64
 ```
 
-### Set your camera IP address define APP name and clear Docker memory
+### Build the Docker image
+
+With the architecture defined, the `acap-opencv-image-capture-cpp` image can be built. The environment variables are supplied as build arguments such that they are made available to docker during the build process:
 
 ```sh
-# Set camera IP
+# Define app name
+APP_NAME=acap-opencv-image-capture-cpp
+
+docker build --tag $APP_NAME --build-arg ARCH .
+```
+
+### Set your device IP address and clear Docker memory
+
+```sh
 DEVICE_IP=<actual camera IP address>
 DOCKER_PORT=2376
 
-# Define APP name
-APP_NAME=acap-opencv-image-capture-cpp
-# Clean docker memory
 docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
 ```
 
-### Build and run the images
+If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap).
+
+### Install the images
+
+Next, the built image needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
 
 ```sh
-docker build --tag $APP_NAME --build-arg ARCH .
-
 docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
+```
 
+### Run the container
+
+With the application image on the device, it can be started using `docker-compose.yml`:
+
+```sh
 docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT --file docker-compose.yml up
 
-# Cleanup
+# Terminate with Ctrl-C and cleanup
 docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT --file docker-compose.yml down -v
 ```
 

--- a/opencv-image-capture-cpp/README.md
+++ b/opencv-image-capture-cpp/README.md
@@ -81,14 +81,14 @@ docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
 ### Build and run the images
 
 ```sh
-docker build . -t $APP_NAME --build-arg ARCH
+docker build . --tag $APP_NAME --build-arg ARCH
 
 docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 
-docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT -f docker-compose.yml up
+docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT --file docker-compose.yml up
 
 # Cleanup
-docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT -f docker-compose.yml down -v
+docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT --file docker-compose.yml down -v
 ```
 
 #### The expected output

--- a/opencv-image-capture-cpp/README.md
+++ b/opencv-image-capture-cpp/README.md
@@ -81,7 +81,7 @@ docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
 ### Build and run the images
 
 ```sh
-docker build . --tag $APP_NAME --build-arg ARCH
+docker build --tag $APP_NAME --build-arg ARCH .
 
 docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 

--- a/opencv-image-capture-cpp/README.md
+++ b/opencv-image-capture-cpp/README.md
@@ -104,7 +104,7 @@ With the application image on the device, it can be started using `docker-compos
 docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --file docker-compose.yml up
 
 # Terminate with Ctrl-C and cleanup
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --file docker-compose.yml down -v
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --file docker-compose.yml down --volumes
 ```
 
 #### The expected output

--- a/opencv-qr-decoder-python/README.md
+++ b/opencv-qr-decoder-python/README.md
@@ -88,7 +88,7 @@ With the application image on the device, it can be started. As the example uses
 docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT up
 
 # Terminate with Ctrl-C and cleanup
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT down -v
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT down --volumes
 ```
 
 ## License

--- a/opencv-qr-decoder-python/README.md
+++ b/opencv-qr-decoder-python/README.md
@@ -80,7 +80,7 @@ Next, the built images needs to be uploaded to the device. This can be done thro
 docker save $APP_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT load
 ```
 
-### Run the containers
+### Run the container
 
 With the application image on the device, it can be started. As the example uses OpenCV, the OpenCV requirements will be included in `docker-compose.yml`, which is used to run the application:
 

--- a/opencv-qr-decoder-python/README.md
+++ b/opencv-qr-decoder-python/README.md
@@ -68,7 +68,7 @@ docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
 With the environment setup, the `acap-opencv-qr-decoder-python` image can be built. The environment variables are supplied as build arguments such that they are made available to docker during the build process:
 
 ```sh
-docker build . -t $APP_NAME --build-arg ARCH
+docker build . --tag $APP_NAME --build-arg ARCH
 ```
 
 Next, the built image needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:

--- a/opencv-qr-decoder-python/README.md
+++ b/opencv-qr-decoder-python/README.md
@@ -68,7 +68,7 @@ docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
 With the environment setup, the `acap-opencv-qr-decoder-python` image can be built. The environment variables are supplied as build arguments such that they are made available to docker during the build process:
 
 ```sh
-docker build . --tag $APP_NAME --build-arg ARCH
+docker build --tag $APP_NAME --build-arg ARCH .
 ```
 
 Next, the built image needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:

--- a/opencv-qr-decoder-python/README.md
+++ b/opencv-qr-decoder-python/README.md
@@ -40,49 +40,54 @@ Meet the following requirements to ensure compatibility with the example:
 
 ### Export the environment variable for the architecture
 
-Export the ARCH variable depending on the architecture of your camera
+Export the `ARCH` variable depending on the architecture of your camera:
 
 ```sh
 # For arm32
 export ARCH=armv7hf
+
 # For arm64
 export ARCH=aarch64
 ```
 
-### Set your camera IP address define APP name and clear Docker memory
+### Build the Docker image
+
+With the architecture defined, the `acap-opencv-qr-decoder-python` image can be built. The environment variables are supplied as build arguments such that they are made available to docker during the build process:
 
 ```sh
-# Set camera IP
-DEVICE_IP=<actual camera IP address>
-DOCKER_PORT=2376
-
-# Define APP name
+# Define app name
 APP_NAME=acap-opencv-qr-decoder-python
 
-# Clean docker memory
-docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
-```
-
-### Build and run the images
-
-With the environment setup, the `acap-opencv-qr-decoder-python` image can be built. The environment variables are supplied as build arguments such that they are made available to docker during the build process:
-
-```sh
 docker build --tag $APP_NAME --build-arg ARCH .
 ```
 
-Next, the built image needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
+### Set your device IP address and clear Docker memory
+
+```sh
+DEVICE_IP=<actual camera IP address>
+DOCKER_PORT=2376
+
+docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
+```
+
+If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap).
+
+### Install the image
+
+Next, the built images needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
 
 ```sh
 docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 ```
+
+### Run the containers
 
 With the application image on the device, it can be started. As the example uses OpenCV, the OpenCV requirements will be included in `docker-compose.yml`, which is used to run the application:
 
 ```sh
 docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT up
 
-# Cleanup after execution
+# Terminate with Ctrl-C and cleanup
 docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT down -v
 ```
 

--- a/opencv-qr-decoder-python/README.md
+++ b/opencv-qr-decoder-python/README.md
@@ -67,7 +67,7 @@ docker build --tag $APP_NAME --build-arg ARCH .
 DEVICE_IP=<actual camera IP address>
 DOCKER_PORT=2376
 
-docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT system prune --all --force
 ```
 
 If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap).
@@ -77,7 +77,7 @@ If you encounter any TLS related issues, please see the TLS setup chapter regard
 Next, the built images needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
 
 ```sh
-docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
+docker save $APP_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT load
 ```
 
 ### Run the containers
@@ -85,10 +85,10 @@ docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 With the application image on the device, it can be started. As the example uses OpenCV, the OpenCV requirements will be included in `docker-compose.yml`, which is used to run the application:
 
 ```sh
-docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT up
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT up
 
 # Terminate with Ctrl-C and cleanup
-docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT down -v
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT down -v
 ```
 
 ## License

--- a/opencv-qr-decoder-python/README.md
+++ b/opencv-qr-decoder-python/README.md
@@ -56,7 +56,7 @@ With the architecture defined, the `acap-opencv-qr-decoder-python` image can be 
 
 ```sh
 # Define app name
-APP_NAME=acap-opencv-qr-decoder-python
+export APP_NAME=acap-opencv-qr-decoder-python
 
 docker build --tag $APP_NAME --build-arg ARCH .
 ```

--- a/parameter-api-cpp/README.md
+++ b/parameter-api-cpp/README.md
@@ -68,24 +68,26 @@ export ARCH=aarch64
 
 ### Build the Docker image
 
+With the architecture defined, the `parameter-api` image can be built. The environment variables are supplied as build arguments such that they are made available to docker during the build process:
+
 ```sh
 # Define app name
 APP_NAME=parameter-api
 
-# Build
+# Build app
 docker build --tag $APP_NAME --build-arg ARCH .
 ```
 
-### Set your camera IP address and clear Docker memory
+### Set your device IP address and clear Docker memory
 
 ```sh
 DEVICE_IP=<actual camera IP address>
 DOCKER_PORT=2376
 
-docker --tlsverify --tlscacert ca.pem --tlscert cert.pem --tlskey key.pem -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
+docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
 ```
 
-where `ca.pem`, `cert.pem` and `key.pem` are the certificates generated when configuring TLS on Docker ACAP.
+If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap).
 
 ### Install the image and required server certificates
 
@@ -122,23 +124,19 @@ curl --anyauth -u "root:$AXIS_TARGET_PASSWORD" "$DEVICE_IP/axis-cgi/applications
 
 where `<password>` is the password to the `root` user.
 
-Finally install the Docker image to the device:
+Finally install the Docker image to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
 
 ```sh
-docker save $APP_NAME | docker --tlsverify --tlscacert ca.pem --tlscert cert.pem --tlskey key.pem -H tcp://$DEVICE_IP:$DOCKER_PORT load
+docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 ```
 
-where `ca.pem`, `cert.pem` and `key.pem` are the certificates generated when configuring TLS on Docker ACAP.
+### Run the container
 
-### Run the image
-
-Use the following command to run the example on the device:
+With the application image on the device, it can be started using `docker-compose.yml`:
 
 ```sh
-docker-compose --tlsverify --tlscacert ca.pem --tlscert cert.pem --tlskey key.pem -H tcp://$DEVICE_IP:$DOCKER_PORT up
+docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT up
 ```
-
-where `ca.pem`, `cert.pem` and `key.pem` are the certificates generated when configuring TLS on Docker ACAP.
 
 ### The expected output
 

--- a/parameter-api-cpp/README.md
+++ b/parameter-api-cpp/README.md
@@ -73,7 +73,7 @@ export ARCH=aarch64
 APP_NAME=parameter-api
 
 # Build
-docker build . -t $APP_NAME --build-arg ARCH
+docker build . --tag $APP_NAME --build-arg ARCH
 ```
 
 ### Set your camera IP address and clear Docker memory

--- a/parameter-api-cpp/README.md
+++ b/parameter-api-cpp/README.md
@@ -72,7 +72,7 @@ With the architecture defined, the `parameter-api` image can be built. The envir
 
 ```sh
 # Define app name
-APP_NAME=parameter-api
+export APP_NAME=parameter-api
 
 # Build app
 docker build --tag $APP_NAME --build-arg ARCH .

--- a/parameter-api-cpp/README.md
+++ b/parameter-api-cpp/README.md
@@ -73,7 +73,7 @@ export ARCH=aarch64
 APP_NAME=parameter-api
 
 # Build
-docker build . --tag $APP_NAME --build-arg ARCH
+docker build --tag $APP_NAME --build-arg ARCH .
 ```
 
 ### Set your camera IP address and clear Docker memory

--- a/parameter-api-cpp/README.md
+++ b/parameter-api-cpp/README.md
@@ -124,7 +124,7 @@ curl --anyauth -u "root:$AXIS_TARGET_PASSWORD" "$DEVICE_IP/axis-cgi/applications
 
 where `<password>` is the password to the `root` user.
 
-Finally install the Docker image to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
+Finally install the application image to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
 
 ```sh
 docker save $APP_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT load
@@ -136,6 +136,9 @@ With the application image on the device, it can be started using `docker-compos
 
 ```sh
 docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT up
+
+# Cleanup
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT down --volumes
 ```
 
 ### The expected output

--- a/parameter-api-cpp/README.md
+++ b/parameter-api-cpp/README.md
@@ -84,7 +84,7 @@ docker build --tag $APP_NAME --build-arg ARCH .
 DEVICE_IP=<actual camera IP address>
 DOCKER_PORT=2376
 
-docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT system prune --all --force
 ```
 
 If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap).
@@ -127,7 +127,7 @@ where `<password>` is the password to the `root` user.
 Finally install the Docker image to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
 
 ```sh
-docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
+docker save $APP_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT load
 ```
 
 ### Run the container
@@ -135,7 +135,7 @@ docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 With the application image on the device, it can be started using `docker-compose.yml`:
 
 ```sh
-docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT up
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT up
 ```
 
 ### The expected output

--- a/parameter-api-python/README.md
+++ b/parameter-api-python/README.md
@@ -68,7 +68,7 @@ export ARCH=aarch64
 
 ```sh
 # Define app name
-APP_NAME=parameter-api
+export APP_NAME=parameter-api
 
 # Build
 docker build --tag $APP_NAME --build-arg ARCH .

--- a/parameter-api-python/README.md
+++ b/parameter-api-python/README.md
@@ -80,10 +80,10 @@ docker build --tag $APP_NAME --build-arg ARCH .
 DEVICE_IP=<actual camera IP address>
 DOCKER_PORT=2376
 
-docker --tlsverify --tlscacert ca.pem --tlscert cert.pem --tlskey key.pem --host tcp://$DEVICE_IP:$DOCKER_PORT system prune --all --force
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT system prune --all --force
 ```
 
-where `ca.pem`, `cert.pem` and `key.pem` are the certificates generated when configuring TLS on Docker ACAP.
+If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap).
 
 ### Install the image and required server certificates
 
@@ -123,17 +123,18 @@ where `<password>` is the password to the `root` user.
 Finally install the Docker image to the device:
 
 ```sh
-docker save $APP_NAME | docker --tlsverify --tlscacert ca.pem --tlscert cert.pem --tlskey key.pem --host tcp://$DEVICE_IP:$DOCKER_PORT load
+docker save $APP_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT load
 ```
-
-where `ca.pem`, `cert.pem` and `key.pem` are the certificates generated when configuring TLS on Docker ACAP.
 
 ### Run the container
 
 With the application image on the device, it can be started using `docker-compose.yml`:
 
 ```sh
-docker-compose --tlsverify --tlscacert ca.pem --tlscert cert.pem --tlskey key.pem --host tcp://$DEVICE_IP:$DOCKER_PORT up
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT up
+
+# Cleanup
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT down --volumes
 ```
 
 where `ca.pem`, `cert.pem` and `key.pem` are the certificates generated when configuring TLS on Docker ACAP.

--- a/parameter-api-python/README.md
+++ b/parameter-api-python/README.md
@@ -71,7 +71,7 @@ export ARCH=aarch64
 APP_NAME=parameter-api
 
 # Build
-docker build . -t $APP_NAME --build-arg ARCH
+docker build . --tag $APP_NAME --build-arg ARCH
 ```
 
 ### Set your camera IP address and clear Docker memory

--- a/parameter-api-python/README.md
+++ b/parameter-api-python/README.md
@@ -80,7 +80,7 @@ docker build --tag $APP_NAME --build-arg ARCH .
 DEVICE_IP=<actual camera IP address>
 DOCKER_PORT=2376
 
-docker --tlsverify --tlscacert ca.pem --tlscert cert.pem --tlskey key.pem -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
+docker --tlsverify --tlscacert ca.pem --tlscert cert.pem --tlskey key.pem --host tcp://$DEVICE_IP:$DOCKER_PORT system prune --all --force
 ```
 
 where `ca.pem`, `cert.pem` and `key.pem` are the certificates generated when configuring TLS on Docker ACAP.
@@ -123,7 +123,7 @@ where `<password>` is the password to the `root` user.
 Finally install the Docker image to the device:
 
 ```sh
-docker save $APP_NAME | docker --tlsverify --tlscacert ca.pem --tlscert cert.pem --tlskey key.pem -H tcp://$DEVICE_IP:$DOCKER_PORT load
+docker save $APP_NAME | docker --tlsverify --tlscacert ca.pem --tlscert cert.pem --tlskey key.pem --host tcp://$DEVICE_IP:$DOCKER_PORT load
 ```
 
 where `ca.pem`, `cert.pem` and `key.pem` are the certificates generated when configuring TLS on Docker ACAP.
@@ -133,7 +133,7 @@ where `ca.pem`, `cert.pem` and `key.pem` are the certificates generated when con
 With the application image on the device, it can be started using `docker-compose.yml`:
 
 ```sh
-docker-compose --tlsverify --tlscacert ca.pem --tlscert cert.pem --tlskey key.pem -H tcp://$DEVICE_IP:$DOCKER_PORT up
+docker-compose --tlsverify --tlscacert ca.pem --tlscert cert.pem --tlskey key.pem --host tcp://$DEVICE_IP:$DOCKER_PORT up
 ```
 
 where `ca.pem`, `cert.pem` and `key.pem` are the certificates generated when configuring TLS on Docker ACAP.

--- a/parameter-api-python/README.md
+++ b/parameter-api-python/README.md
@@ -71,7 +71,7 @@ export ARCH=aarch64
 APP_NAME=parameter-api
 
 # Build
-docker build . --tag $APP_NAME --build-arg ARCH
+docker build --tag $APP_NAME --build-arg ARCH .
 ```
 
 ### Set your camera IP address and clear Docker memory

--- a/parameter-api-python/README.md
+++ b/parameter-api-python/README.md
@@ -74,7 +74,7 @@ APP_NAME=parameter-api
 docker build --tag $APP_NAME --build-arg ARCH .
 ```
 
-### Set your camera IP address and clear Docker memory
+### Set your device IP address and clear Docker memory
 
 ```sh
 DEVICE_IP=<actual camera IP address>
@@ -128,9 +128,9 @@ docker save $APP_NAME | docker --tlsverify --tlscacert ca.pem --tlscert cert.pem
 
 where `ca.pem`, `cert.pem` and `key.pem` are the certificates generated when configuring TLS on Docker ACAP.
 
-### Run the image
+### Run the container
 
-Use the following command to run the example on the device:
+With the application image on the device, it can be started using `docker-compose.yml`:
 
 ```sh
 docker-compose --tlsverify --tlscacert ca.pem --tlscert cert.pem --tlskey key.pem -H tcp://$DEVICE_IP:$DOCKER_PORT up

--- a/pose-estimator-with-flask/README.md
+++ b/pose-estimator-with-flask/README.md
@@ -113,11 +113,11 @@ docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
 docker run -it --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
 
 # Build and upload inference client for camera
-docker build . --tag $APP_NAME --build-arg ARCH
+docker build --tag $APP_NAME --build-arg ARCH .
 docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 
 # Build and upload inference models
-docker build . --file Dockerfile.model --tag $MODEL_NAME --build-arg ARCH
+docker build --file Dockerfile.model --tag $MODEL_NAME --build-arg ARCH .
 docker save $MODEL_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 
 # Use the following command to run the example on the camera

--- a/pose-estimator-with-flask/README.md
+++ b/pose-estimator-with-flask/README.md
@@ -113,11 +113,11 @@ docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
 docker run -it --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
 
 # Build and upload inference client for camera
-docker build . -t $APP_NAME --build-arg ARCH
+docker build . --tag $APP_NAME --build-arg ARCH
 docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 
 # Build and upload inference models
-docker build . -f Dockerfile.model -t $MODEL_NAME --build-arg ARCH
+docker build . --file Dockerfile.model --tag $MODEL_NAME --build-arg ARCH
 docker save $MODEL_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 
 # Use the following command to run the example on the camera

--- a/pose-estimator-with-flask/README.md
+++ b/pose-estimator-with-flask/README.md
@@ -103,7 +103,7 @@ DOCKER_PORT=2376
 # Define app name
 APP_NAME=acap4-pose-estimator-python
 MODEL_NAME=acap-dl-models
-docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT system prune --all --force
 ```
 
 ### Build the pose-estimator-with-flask images
@@ -114,17 +114,17 @@ docker run -it --rm --privileged multiarch/qemu-user-static --credential yes --p
 
 # Build and upload inference client for camera
 docker build --tag $APP_NAME --build-arg ARCH .
-docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
+docker save $APP_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT load
 
 # Build and upload inference models
 docker build --file Dockerfile.model --tag $MODEL_NAME --build-arg ARCH .
-docker save $MODEL_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
+docker save $MODEL_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT load
 
 # Use the following command to run the example on the camera
-docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP up
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP up
 
 # Terminate with Ctrl-C and cleanup
-docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP down -v
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP down -v
 ```
 
 ### The expected output

--- a/pose-estimator-with-flask/README.md
+++ b/pose-estimator-with-flask/README.md
@@ -96,33 +96,51 @@ export ARCH=aarch64
 export CHIP=artpec8
 ```
 
+### Build the Docker images
+
+With the architecture defined, the `acap4-pose-estimator-python` and `acap-dl-models` images can be built. The environment variables are supplied as build arguments such that they are made available to docker during the build process:
+
+```sh
+# Define app name
+export APP_NAME=acap4-pose-estimator-python
+export MODEL_NAME=acap-dl-models
+
+# Install qemu to allow build flask for a different architecture
+docker run --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
+
+# Build app
+docker build --tag $APP_NAME --build-arg ARCH .
+
+# Build inference model
+docker build --file Dockerfile.model --tag $MODEL_NAME --build-arg ARCH .
+```
+
 ### Set your device IP address and clear Docker memory
 
 ```sh
 DEVICE_IP=<actual camera IP address>
 DOCKER_PORT=2376
 
-# Define app name
-export APP_NAME=acap4-pose-estimator-python
-MODEL_NAME=acap-dl-models
 docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT system prune --all --force
 ```
 
-### Build the pose-estimator-with-flask images
+If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap).
+
+### Install the images
+
+Next, the built images needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
 
 ```sh
-# Install qemu to allow build flask for a different architecture
-docker run --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
-
-# Build and upload inference client for camera
-docker build --tag $APP_NAME --build-arg ARCH .
 docker save $APP_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT load
 
-# Build and upload inference models
-docker build --file Dockerfile.model --tag $MODEL_NAME --build-arg ARCH .
 docker save $MODEL_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT load
+```
 
-# Use the following command to run the example on the camera
+### Run the containers
+
+With the application image on the device, it can be started using `docker-compose.yml`:
+
+```sh
 docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP up
 
 # Terminate with Ctrl-C and cleanup
@@ -163,11 +181,12 @@ pose-estimator_1    |  0.02048427 0.01638742 0.15568045 0.07374337 0.05735596]
 
 ### Hardware acceleration
 
-The ./config folder contains configuration files with the parameters to run the inference on different camera models. The parameters also gives you the possibility to use the hardware accelerator.
+The `./config` folder contains configuration files with the parameters to run the inference on different camera models. The parameters also gives you the possibility to use the hardware accelerator.
+
 To achieve the best performance we recommend using:
 
-* the TPU (Tensor Processing Unit) equipped with artpec7 cameras (for example [Axis-Q1615 Mk III](https://www.axis.com/products/axis-q1615-mk-iii))
-* or the DLPU (Deep Learning Processing Unit) equipped in artpec8 cameras (e.g. [Axis-Q1656](https://www.axis.com/products/axis-q1656))
+* the TPU (Tensor Processing Unit) equipped with ARTPEC-7 cameras (for example [Axis-Q1615 Mk III](https://www.axis.com/products/axis-q1615-mk-iii))
+* or the DLPU (Deep Learning Processing Unit) equipped in ARTPEC-8 cameras (e.g. [Axis-Q1656](https://www.axis.com/products/axis-q1656))
 
 ## License
 

--- a/pose-estimator-with-flask/README.md
+++ b/pose-estimator-with-flask/README.md
@@ -124,7 +124,7 @@ docker save $MODEL_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_POR
 docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP up
 
 # Terminate with Ctrl-C and cleanup
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP down -v
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP down --volumes
 ```
 
 ### The expected output

--- a/pose-estimator-with-flask/README.md
+++ b/pose-estimator-with-flask/README.md
@@ -78,7 +78,7 @@ Meet the following requirements to ensure compatibility with the example:
 
 ### Export the environment variable for the architecture
 
-Export the ARCH variable depending on the architecture of your camera
+Export the `ARCH` variable depending on the architecture of your camera:
 
 ```sh
 # For arm32
@@ -94,13 +94,13 @@ export ARCH=aarch64
 export CHIP=artpec8
 ```
 
-### Set your camera IP address and clear Docker memory
+### Set your device IP address and clear Docker memory
 
 ```sh
 DEVICE_IP=<actual camera IP address>
 DOCKER_PORT=2376
 
-# Define APP name
+# Define app name
 APP_NAME=acap4-pose-estimator-python
 MODEL_NAME=acap-dl-models
 docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af

--- a/pose-estimator-with-flask/README.md
+++ b/pose-estimator-with-flask/README.md
@@ -103,7 +103,7 @@ DEVICE_IP=<actual camera IP address>
 DOCKER_PORT=2376
 
 # Define app name
-APP_NAME=acap4-pose-estimator-python
+export APP_NAME=acap4-pose-estimator-python
 MODEL_NAME=acap-dl-models
 docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT system prune --all --force
 ```

--- a/pose-estimator-with-flask/README.md
+++ b/pose-estimator-with-flask/README.md
@@ -83,6 +83,7 @@ Export the `ARCH` variable depending on the architecture of your camera:
 ```sh
 # For arm32
 export ARCH=armv7hf
+
 # Valid options for chip on armv7hf are 'tpu' (hardware accelerator) or 'cpu'
 export CHIP=tpu
 ```
@@ -90,6 +91,7 @@ export CHIP=tpu
 ```sh
 # For arm64
 export ARCH=aarch64
+
 # Valid options for chip on aarch64 are 'artpec8' (hardware accelerator) or 'cpu'
 export CHIP=artpec8
 ```

--- a/pose-estimator-with-flask/README.md
+++ b/pose-estimator-with-flask/README.md
@@ -110,7 +110,7 @@ docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT system prune --all --for
 
 ```sh
 # Install qemu to allow build flask for a different architecture
-docker run -it --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
+docker run --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
 
 # Build and upload inference client for camera
 docker build --tag $APP_NAME --build-arg ARCH .

--- a/web-server/README.md
+++ b/web-server/README.md
@@ -87,7 +87,7 @@ docker build --tag $APP_NAME --build-arg ARCH .
 DEVICE_IP=<actual camera IP address>
 DOCKER_PORT=2376
 
-docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT system prune --all --force
 ```
 
 If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap).
@@ -97,7 +97,7 @@ If you encounter any TLS related issues, please see the TLS setup chapter regard
 Next, the built image needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
 
 ```sh
-docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
+docker save $APP_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT load
 ```
 
 ### Run the container
@@ -105,10 +105,10 @@ docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 With the application image on the device, it can be started using `docker-compose.yml`:
 
 ```sh
-docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT up
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT up
 
 # Terminate with Ctrl-C and cleanup
-docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT down -v
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT down -v
 ```
 
 ### The expected output
@@ -132,13 +132,13 @@ Some C API examples are included in the Web Server container that has been built
 
 ```sh
 # Run the hello example
-docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT  run --rm -p 2001:2001 -it $APP_NAME hello
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT  run --rm -p 2001:2001 -it $APP_NAME hello
 
 # Run the list directory example
-docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT  run --rm -p 2001:2001 -it $APP_NAME list
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT  run --rm -p 2001:2001 -it $APP_NAME list
 
 # Run the quiz example
-docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT  run --rm -p 2001:2001 -it $APP_NAME quiz
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT  run --rm -p 2001:2001 -it $APP_NAME quiz
 ```
 
 ## Proxy settings

--- a/web-server/README.md
+++ b/web-server/README.md
@@ -132,13 +132,13 @@ Some C API examples are included in the Web Server container that has been built
 
 ```sh
 # Run the hello example
-docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT  run --rm -p 2001:2001 -it $APP_NAME hello
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT  run --rm --publish 2001:2001 -it $APP_NAME hello
 
 # Run the list directory example
-docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT  run --rm -p 2001:2001 -it $APP_NAME list
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT  run --rm --publish 2001:2001 -it $APP_NAME list
 
 # Run the quiz example
-docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT  run --rm -p 2001:2001 -it $APP_NAME quiz
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT  run --rm --publish 2001:2001 -it $APP_NAME quiz
 ```
 
 ## Proxy settings

--- a/web-server/README.md
+++ b/web-server/README.md
@@ -108,7 +108,7 @@ With the application image on the device, it can be started using `docker-compos
 docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT up
 
 # Terminate with Ctrl-C and cleanup
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT down -v
+docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT down
 ```
 
 ### The expected output

--- a/web-server/README.md
+++ b/web-server/README.md
@@ -71,11 +71,11 @@ export ARCH=aarch64
 With the architecture defined, the `monkey` image can be built. The environment variables are supplied as build arguments such that they are made available to docker during the build process:
 
 ```sh
-# Install qemu emulator to build for different architectures
-docker run --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
-
 # Define app name
 export APP_NAME=monkey
+
+# Install qemu emulator to build for different architectures
+docker run --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
 
 # Build the container
 docker build --tag $APP_NAME --build-arg ARCH .

--- a/web-server/README.md
+++ b/web-server/README.md
@@ -75,7 +75,7 @@ With the architecture defined, the `monkey` image can be built. The environment 
 docker run --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
 
 # Define app name
-APP_NAME=monkey
+export APP_NAME=monkey
 
 # Build the container
 docker build --tag $APP_NAME --build-arg ARCH .

--- a/web-server/README.md
+++ b/web-server/README.md
@@ -56,39 +56,43 @@ Start by building the image containing the Web Server code with examples. This w
 
 ### Export the environment variable for the architecture
 
-Export the ARCH variable depending on the architecture of your camera
+Export the `ARCH` variable depending on the architecture of your camera:
 
 ```sh
 # For arm32
 export ARCH=armv7hf
+
 # For arm64
 export ARCH=aarch64
 ```
 
-### Set your camera IP address define APP name and clear Docker memory
+### Build the Docker image
 
-```sh
-# Set camera IP
-DEVICE_IP=<actual camera IP address>
-DOCKER_PORT=2376
-
-# Define APP name
-APP_NAME=monkey
-# Clean docker memory
-docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
-```
-
-### Build and run the images
-
-With the environment setup, the `monkey` image can be built. The environment variables are supplied as build arguments such that they are made available to docker during the build process:
+With the architecture defined, the `monkey` image can be built. The environment variables are supplied as build arguments such that they are made available to docker during the build process:
 
 ```sh
 # Install qemu emulator to build for different architectures
 docker run --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
 
+# Define app name
+APP_NAME=monkey
+
 # Build the container
 docker build --tag $APP_NAME --build-arg ARCH .
 ```
+
+### Set your device IP address and clear Docker memory
+
+```sh
+DEVICE_IP=<actual camera IP address>
+DOCKER_PORT=2376
+
+docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT system prune -af
+```
+
+If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap).
+
+### Install the image
 
 Next, the built image needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
 
@@ -96,14 +100,14 @@ Next, the built image needs to be uploaded to the device. This can be done throu
 docker save $APP_NAME | docker --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT load
 ```
 
-### Start Web Server on the camera
+### Run the container
 
 With the application image on the device, it can be started using `docker-compose.yml`:
 
 ```sh
 docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT up
 
-# Cleanup after execution
+# Terminate with Ctrl-C and cleanup
 docker-compose --tlsverify -H tcp://$DEVICE_IP:$DOCKER_PORT down -v
 ```
 

--- a/web-server/README.md
+++ b/web-server/README.md
@@ -87,7 +87,7 @@ With the environment setup, the `monkey` image can be built. The environment var
 docker run --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
 
 # Build the container
-docker build . -t $APP_NAME --build-arg ARCH
+docker build . --tag $APP_NAME --build-arg ARCH
 ```
 
 Next, the built image needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:

--- a/web-server/README.md
+++ b/web-server/README.md
@@ -87,7 +87,7 @@ With the environment setup, the `monkey` image can be built. The environment var
 docker run --rm --privileged multiarch/qemu-user-static --credential yes --persistent yes
 
 # Build the container
-docker build . --tag $APP_NAME --build-arg ARCH
+docker build --tag $APP_NAME --build-arg ARCH .
 ```
 
 Next, the built image needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:


### PR DESCRIPTION
### Describe your changes

Feedback indicate that the steps in running the examples sometimes are confusing. E.g. some variables are declared early but then not used until much later on. The same goes for interactions with the device. We clean the device from dangling Docker images before we've even build our new application image.

I've made the following changes to the documentation, please deem whether they are an improvement or not.

- Reorganized the examples steps into
  1. Export the environment variable for the architecture
  2. Build the Docker image(s)
  3. Set your device IP address and clear Docker memory
  4. Install the image(s)
  5. Run the container(s)
- Made sure to use the long name flags when calling `docker` instead of the short names. Short name can sometimes be confusing, e.g. I was unsure myself whether `-v` in `docker-compose down` meant *verbose* or *volumes*
- Made sure that context was the last specified parameter when calling `docker build`
- Removed command to remove built image in GitHub Actions workflows. We are not caching the images between runs, thus I don't think removing the image before the workflow ends has any actual affect on shared state between runs.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [ ] I have verified that the code builds perfectly fine on my local system (parameter-api-python does currently not work, I'm in contact with the example owners)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
