### PR TITLE
Removed override flag for ACAP Runtime usage

### DIFF
--- a/minimal-ml-inference/config/env.aarch64.artpec8
+++ b/minimal-ml-inference/config/env.aarch64.artpec8
@@ -1,3 +1,3 @@
 MODEL_PATH=/models/ssd_mobilenet_v2_coco_quant_postprocess.tflite
-INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:1.1.2-aarch64-containerized
+INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:1.2.0-aarch64-containerized
 INFERENCE_CHIP=12

--- a/minimal-ml-inference/config/env.aarch64.cpu
+++ b/minimal-ml-inference/config/env.aarch64.cpu
@@ -1,3 +1,3 @@
 MODEL_PATH=/models/ssd_mobilenet_v2_coco_quant_postprocess.tflite
-INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:1.1.2-aarch64-containerized
+INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:1.2.0-aarch64-containerized
 INFERENCE_CHIP=2

--- a/minimal-ml-inference/config/env.armv7hf.cpu
+++ b/minimal-ml-inference/config/env.armv7hf.cpu
@@ -1,3 +1,3 @@
 MODEL_PATH=/models/ssd_mobilenet_v2_coco_quant_postprocess.tflite
-INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:1.1.2-armv7hf-containerized
+INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:1.2.0-armv7hf-containerized
 INFERENCE_CHIP=2

--- a/minimal-ml-inference/config/env.armv7hf.tpu
+++ b/minimal-ml-inference/config/env.armv7hf.tpu
@@ -1,3 +1,3 @@
 MODEL_PATH=/models/ssd_mobilenet_v2_coco_quant_postprocess_edgetpu.tflite
-INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:1.1.2-armv7hf-containerized
+INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:1.2.0-armv7hf-containerized
 INFERENCE_CHIP=4

--- a/minimal-ml-inference/docker-compose.yml
+++ b/minimal-ml-inference/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       options:
         max-file: "5"
         max-size: "100k"
-    entrypoint: ["/opt/app/acap_runtime/acapruntime", "-o", "-m", "${MODEL_PATH}", "-j", "${INFERENCE_CHIP}"]
+    entrypoint: ["/opt/app/acap_runtime/acapruntime", "-m", "${MODEL_PATH}", "-j", "${INFERENCE_CHIP}"]
     volumes:
       - /usr/acap-root/lib:/host/lib
       - acap_dl-models:/models:ro

--- a/object-detector-cpp/config/env.aarch64.artpec8
+++ b/object-detector-cpp/config/env.aarch64.artpec8
@@ -1,3 +1,3 @@
 MODEL_PATH=/models/ssd_mobilenet_v2_coco_quant_postprocess.tflite
-INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:1.1.2-aarch64-containerized
+INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:1.2.0-aarch64-containerized
 INFERENCE_CHIP=12

--- a/object-detector-cpp/config/env.aarch64.cpu
+++ b/object-detector-cpp/config/env.aarch64.cpu
@@ -1,3 +1,3 @@
 MODEL_PATH=/models/ssd_mobilenet_v2_coco_quant_postprocess.tflite
-INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:1.1.2-aarch64-containerized
+INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:1.2.0-aarch64-containerized
 INFERENCE_CHIP=2

--- a/object-detector-cpp/config/env.armv7hf.cpu
+++ b/object-detector-cpp/config/env.armv7hf.cpu
@@ -1,3 +1,3 @@
 MODEL_PATH=/models/ssd_mobilenet_v2_coco_quant_postprocess.tflite
-INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:1.1.2-armv7hf-containerized
+INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:1.2.0-armv7hf-containerized
 INFERENCE_CHIP=2

--- a/object-detector-cpp/config/env.armv7hf.tpu
+++ b/object-detector-cpp/config/env.armv7hf.tpu
@@ -1,3 +1,3 @@
 MODEL_PATH=/models/ssd_mobilenet_v2_coco_quant_postprocess_edgetpu.tflite
-INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:1.1.2-armv7hf-containerized
+INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:1.2.0-armv7hf-containerized
 INFERENCE_CHIP=4

--- a/object-detector-cpp/docker-compose.yml
+++ b/object-detector-cpp/docker-compose.yml
@@ -25,7 +25,7 @@ services:
         options:
           max-file: "5"
           max-size: "100k"
-      entrypoint: ["/opt/app/acap_runtime/acapruntime", "-o", "-m", "${MODEL_PATH}", "-j", "${INFERENCE_CHIP}", "-c", "/models/server.pem", "-k", "/models/server.key"]
+      entrypoint: ["/opt/app/acap_runtime/acapruntime", "-m", "${MODEL_PATH}", "-j", "${INFERENCE_CHIP}", "-c", "/models/server.pem", "-k", "/models/server.key"]
       depends_on:
         - acap_dl-models
       ipc: host

--- a/object-detector-python/config/env.aarch64.artpec8
+++ b/object-detector-python/config/env.aarch64.artpec8
@@ -1,3 +1,3 @@
 MODEL_PATH=/models/ssd_mobilenet_v2_coco_quant_postprocess.tflite
-INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:1.1.2-aarch64-containerized
+INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:1.2.0-aarch64-containerized
 INFERENCE_CHIP=12

--- a/object-detector-python/config/env.aarch64.cpu
+++ b/object-detector-python/config/env.aarch64.cpu
@@ -1,3 +1,3 @@
 MODEL_PATH=/models/ssd_mobilenet_v2_coco_quant_postprocess.tflite
-INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:1.1.2-aarch64-containerized
+INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:1.2.0-aarch64-containerized
 INFERENCE_CHIP=2

--- a/object-detector-python/config/env.armv7hf.cpu
+++ b/object-detector-python/config/env.armv7hf.cpu
@@ -1,3 +1,3 @@
 MODEL_PATH=/models/ssd_mobilenet_v2_coco_quant_postprocess.tflite
-INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:1.1.2-armv7hf-containerized
+INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:1.2.0-armv7hf-containerized
 INFERENCE_CHIP=2

--- a/object-detector-python/config/env.armv7hf.tpu
+++ b/object-detector-python/config/env.armv7hf.tpu
@@ -1,3 +1,3 @@
 MODEL_PATH=/models/ssd_mobilenet_v2_coco_quant_postprocess_edgetpu.tflite
-INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:1.1.2-armv7hf-containerized
+INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:1.2.0-armv7hf-containerized
 INFERENCE_CHIP=4

--- a/object-detector-python/docker-compose.yml
+++ b/object-detector-python/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       options:
         max-file: "5"
         max-size: "100k"
-    entrypoint: ["/opt/app/acap_runtime/acapruntime", "-o", "-m", "${MODEL_PATH}", "-j", "${INFERENCE_CHIP}"]
+    entrypoint: ["/opt/app/acap_runtime/acapruntime", "-m", "${MODEL_PATH}", "-j", "${INFERENCE_CHIP}"]
     volumes:
       - /usr/acap-root/lib:/host/lib
       - acap_dl-models:/models:ro

--- a/pose-estimator-with-flask/config/env.aarch64.artpec8
+++ b/pose-estimator-with-flask/config/env.aarch64.artpec8
@@ -1,3 +1,3 @@
 MODEL_PATH=/models/movenet_single_pose_lightning_ptq.tflite
-INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:1.1.2-aarch64-containerized
+INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:1.2.0-aarch64-containerized
 INFERENCE_CHIP=12

--- a/pose-estimator-with-flask/config/env.aarch64.cpu
+++ b/pose-estimator-with-flask/config/env.aarch64.cpu
@@ -1,3 +1,3 @@
 MODEL_PATH=/models/movenet_single_pose_lightning_ptq.tflite
-INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:1.1.2-aarch64-containerized
+INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:1.2.0-aarch64-containerized
 INFERENCE_CHIP=2

--- a/pose-estimator-with-flask/config/env.armv7hf.cpu
+++ b/pose-estimator-with-flask/config/env.armv7hf.cpu
@@ -1,4 +1,4 @@
 MODEL_PATH=/models/movenet_single_pose_lightning_ptq.tflite
-INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:1.1.2-armv7hf-containerized
+INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:1.2.0-armv7hf-containerized
 INFERENCE_CHIP=2
 

--- a/pose-estimator-with-flask/config/env.armv7hf.tpu
+++ b/pose-estimator-with-flask/config/env.armv7hf.tpu
@@ -1,4 +1,4 @@
 MODEL_PATH=/models/movenet_single_pose_lightning_ptq_edgetpu.tflite
-INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:1.1.2-armv7hf-containerized
+INFERENCE_SERVER_IMAGE=axisecp/acap-runtime:1.2.0-armv7hf-containerized
 INFERENCE_CHIP=4
 

--- a/pose-estimator-with-flask/docker-compose.yml
+++ b/pose-estimator-with-flask/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       options:
         max-file: "5"
         max-size: "100k"
-    entrypoint: ["/opt/app/acap_runtime/acapruntime", "-o", "-m", "${MODEL_PATH}", "-j", "${INFERENCE_CHIP}"]
+    entrypoint: ["/opt/app/acap_runtime/acapruntime", "-m", "${MODEL_PATH}", "-j", "${INFERENCE_CHIP}"]
     volumes:
       - /usr/acap-root/lib:/host/lib
       - acap_dl-models:/models:ro


### PR DESCRIPTION
From ACAP Runtime 1.2.0 the function of the override flag has changed.
- Fixes [#(95)](https://github.com/AxisCommunications/acap-computer-vision-sdk-examples/issues/95)

### Describe your changes

The examples that use the ACAP Runtime containerized version need to be updated to work with the change.
