### PR TITLE
static-image-fix

### DIFF
--- a/object-detector-python/docker-compose.yml
+++ b/object-detector-python/docker-compose.yml
@@ -45,4 +45,3 @@ services:
 volumes:
   acap_dl-models: {}
   inference-server: {}
-

--- a/object-detector-python/static-image.yml
+++ b/object-detector-python/static-image.yml
@@ -1,7 +1,7 @@
 version: '3.3'
 services:
   object-detector-python:
-    image: $APP_NAME
+    image: ${APP_NAME}
     logging:
       driver: "json-file"
       options:
@@ -9,8 +9,8 @@ services:
         max-size: "100k"
     environment:
       - PYTHONUNBUFFERED=1
-      - INFERENCE_HOST=inference-server
-      - INFERENCE_PORT=8501
+      - INFERENCE_HOST=unix:///tmp/acap-runtime.sock
+      - INFERENCE_PORT=0
       - MODEL_PATH=${MODEL_PATH}
       - OBJECT_LIST_PATH=/models/coco_labels.txt
       - IMAGE_PATH=dog416.png
@@ -19,24 +19,30 @@ services:
       - acap_dl-models:/models:ro
       - /tmp:/output
       - /var/run/dbus:/var/run/dbus:rw
+      - inference-server:/tmp
 
   inference-server:
-    image:  ${INFERENCE_SERVER_IMAGE}
+    image: ${INFERENCE_SERVER_IMAGE}
     logging:
       driver: "json-file"
       options:
         max-file: "5"
         max-size: "100k"
-    command: ${INFERENCE_SERVER_COMMAND}
+    entrypoint: ["/opt/app/acap_runtime/acapruntime", "-m", "${MODEL_PATH}", "-j", "${INFERENCE_CHIP}"]
     volumes:
       - /usr/acap-root/lib:/host/lib
       - acap_dl-models:/models:ro
       - /run/dbus/system_bus_socket:/run/dbus/system_bus_socket
+      - /run/parhand/parhandsocket:/run/parhand/parhandsocket
+      - /usr/lib:/usr/lib
+      - /usr/bin:/usr/bin
+      - inference-server:/tmp
 
   acap_dl-models:
-    image: $MODEL_NAME
+    image: ${MODEL_NAME}
     volumes:
       - acap_dl-models:/models
 
 volumes:
   acap_dl-models: {}
+  inference-server: {}


### PR DESCRIPTION
### Describe your changes

The static-image.yml in the object-detector-python was not up-to-date after the changes in the acap-runtime. Fixed

### Issue ticket number and link

- Fixes [#(127)](https://github.com/AxisCommunications/acap-computer-vision-sdk-examples/issues/127)

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
