### PR TITLE
Changing docker-compose to docker compose

### DIFF
--- a/hello-world-cpp/README.md
+++ b/hello-world-cpp/README.md
@@ -32,7 +32,8 @@ Meet the following requirements to ensure compatibility with the example:
   * Firmware: 10.9 or higher
   * [Docker ACAP](https://github.com/AxisCommunications/docker-acap) installed and started, using TLS and SD card as storage
 * Computer
-  * Either [Docker Desktop](https://docs.docker.com/desktop/) version 4.11.1 or higher, or [Docker Engine](https://docs.docker.com/engine/) version 20.10.17 or higher with BuildKit enabled using Docker Compose version 1.29.2 or higher
+  * Either [Docker Desktop](https://docs.docker.com/desktop/) version 4.11.1 or higher,
+  * or [Docker Engine](https://docs.docker.com/engine/) version 20.10.17 or higher with BuildKit enabled using Docker Compose version 1.29.2 or higher
 
 ## How to run the code
 
@@ -84,10 +85,10 @@ docker save $APP_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT 
 With the application image on the device, it can be started. As the example uses OpenCV, the OpenCV requirements will be included in `docker-compose.yml`, which is used to run the application:
 
 ```sh
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT up
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT compose up
 
 # Cleanup
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT down --volumes
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT compose down --volumes
 ```
 
 The expected output from the application is (depending on the OpenCV pulled from the ACAP Computer Vision SDK):

--- a/hello-world-python/README.md
+++ b/hello-world-python/README.md
@@ -32,7 +32,8 @@ Meet the following requirements to ensure compatibility with the example:
   * Firmware: 10.9 or higher
   * [Docker ACAP](https://github.com/AxisCommunications/docker-acap) installed and started, using TLS and SD card as storage
 * Computer
-  * Either [Docker Desktop](https://docs.docker.com/desktop/) version 4.11.1 or higher, or [Docker Engine](https://docs.docker.com/engine/) version 20.10.17 or higher with BuildKit enabled using Docker Compose version 1.29.2 or higher
+  * Either [Docker Desktop](https://docs.docker.com/desktop/) version 4.11.1 or higher,
+  * or [Docker Engine](https://docs.docker.com/engine/) version 20.10.17 or higher with BuildKit enabled using Docker Compose version 1.29.2 or higher
 
 ## How to run the code
 
@@ -83,10 +84,10 @@ docker save $APP_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT 
 With the application image on the device, it can be started using `docker-compose.yml`:
 
 ```sh
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT up
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT compose up
 
 # Cleanup
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT down
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT compose down
 ```
 
 The expected output from the application is simply:

--- a/minimal-ml-inference/README.md
+++ b/minimal-ml-inference/README.md
@@ -37,7 +37,8 @@ Meet the following requirements to ensure compatibility with the example:
   * Firmware: 10.9 or higher
   * [Docker ACAP](https://github.com/AxisCommunications/docker-acap) installed and started, using TLS and SD card as storage
 * Computer
-  * Either [Docker Desktop](https://docs.docker.com/desktop/) version 4.11.1 or higher, or [Docker Engine](https://docs.docker.com/engine/) version 20.10.17 or higher with BuildKit enabled using Docker Compose version 1.29.2 or higher
+  * Either [Docker Desktop](https://docs.docker.com/desktop/) version 4.11.1 or higher,
+  * or [Docker Engine](https://docs.docker.com/engine/) version 20.10.17 or higher with BuildKit enabled using Docker Compose version 1.29.2 or higher
 
 ## How to run the code
 
@@ -106,10 +107,10 @@ docker save $MODEL_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_POR
 With the application image on the device, it can be started using `docker-compose.yml`:
 
 ```sh
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP up
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP compose up
 
 # Terminate with Ctrl-C and cleanup
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP down --volumes
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP compose down --volumes
 ```
 
 The expected output from the application is the raw predictions from the model specified in the environment variable.

--- a/object-detector-cpp/README.md
+++ b/object-detector-cpp/README.md
@@ -46,7 +46,8 @@ Meet the following requirements to ensure compatibility with the example:
   * Firmware: 10.9 or higher
   * [Docker ACAP](https://github.com/AxisCommunications/docker-acap) installed and started, using TLS and SD card as storage
 * Computer
-  * Either [Docker Desktop](https://docs.docker.com/desktop/) version 4.11.1 or higher, or [Docker Engine](https://docs.docker.com/engine/) version 20.10.17 or higher with BuildKit enabled using Docker Compose version 1.29.2 or higher
+  * Either [Docker Desktop](https://docs.docker.com/desktop/) version 4.11.1 or higher,
+  * or [Docker Engine](https://docs.docker.com/engine/) version 20.10.17 or higher with BuildKit enabled using Docker Compose version 1.29.2 or higher
 
 ## How to run the code
 
@@ -115,10 +116,10 @@ docker save $MODEL_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_POR
 With the images on the device, they can be started using `docker-compose.yml`:
 
 ```sh
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP up
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP compose up
 
 # Terminate with Ctrl-C and cleanup
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP down --volumes
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP compose down --volumes
 ```
 
 ### The expected output

--- a/object-detector-python/README.md
+++ b/object-detector-python/README.md
@@ -59,7 +59,8 @@ Meet the following requirements to ensure compatibility with the example:
   * Firmware: 10.9 or higher
   * [Docker ACAP](https://github.com/AxisCommunications/docker-acap) installed and started, using TLS and SD card as storage
 * Computer
-  * Either [Docker Desktop](https://docs.docker.com/desktop/) version 4.11.1 or higher, or [Docker Engine](https://docs.docker.com/engine/) version 20.10.17 or higher with BuildKit enabled using Docker Compose version 1.29.2 or higher
+  * Either [Docker Desktop](https://docs.docker.com/desktop/) version 4.11.1 or higher,
+  * or [Docker Engine](https://docs.docker.com/engine/) version 20.10.17 or higher with BuildKit enabled using Docker Compose version 1.29.2 or higher
 
 ## How to run the code
 
@@ -128,23 +129,23 @@ docker save $MODEL_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_POR
 With the application image on the device, it can be started using `docker-compose.yml`:
 
 ```sh
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP up
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP compose up
 
 # Terminate with Ctrl-C and cleanup
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP down --volumes
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP compose down --volumes
 ```
 
 ### The expected output
 
 ```sh
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP up
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP compose up
 ....
 object-detector_1           | 1 Objects found
 object-detector_1           | person
 ```
 
 ```sh
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --file static-image.yml --env-file ./config/env.$ARCH.$CHIP up
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --file static-image.yml --env-file ./config/env.$ARCH.$CHIP compose up
 ....
 object-detector-python_1          | 3 Objects found
 object-detector-python_1          | bicycle

--- a/opencv-image-capture-cpp/README.md
+++ b/opencv-image-capture-cpp/README.md
@@ -25,7 +25,8 @@ Meet the following requirements to ensure compatibility with the example:
   * Firmware: 10.9 or higher
   * [Docker ACAP](https://github.com/AxisCommunications/docker-acap) installed and started, using TLS and SD card as storage
 * Computer
-  * Either [Docker Desktop](https://docs.docker.com/desktop/) version 4.11.1 or higher, or [Docker Engine](https://docs.docker.com/engine/) version 20.10.17 or higher with BuildKit enabled using Docker Compose version 1.29.2 or higher
+  * Either [Docker Desktop](https://docs.docker.com/desktop/) version 4.11.1 or higher,
+  * or [Docker Engine](https://docs.docker.com/engine/) version 20.10.17 or higher with BuildKit enabled using Docker Compose version 1.29.2 or higher
 
 ## Getting started
 
@@ -101,10 +102,10 @@ docker save $APP_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT 
 With the application image on the device, it can be started using `docker-compose.yml`:
 
 ```sh
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT up
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT compose up
 
 # Terminate with Ctrl-C and cleanup
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT down --volumes
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT compose down --volumes
 ```
 
 #### The expected output

--- a/opencv-qr-decoder-python/README.md
+++ b/opencv-qr-decoder-python/README.md
@@ -34,7 +34,8 @@ Meet the following requirements to ensure compatibility with the example:
   * Firmware: 10.9 or higher
   * [Docker ACAP](https://github.com/AxisCommunications/docker-acap) installed and started, using TLS and SD card as storage
 * Computer
-  * Either [Docker Desktop](https://docs.docker.com/desktop/) version 4.11.1 or higher, or [Docker Engine](https://docs.docker.com/engine/) version 20.10.17 or higher with BuildKit enabled using Docker Compose version 1.29.2 or higher
+  * Either [Docker Desktop](https://docs.docker.com/desktop/) version 4.11.1 or higher,
+  * or [Docker Engine](https://docs.docker.com/engine/) version 20.10.17 or higher with BuildKit enabled using Docker Compose version 1.29.2 or higher
 
 ## How to run the code
 
@@ -85,10 +86,10 @@ docker save $APP_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT 
 With the application image on the device, it can be started. As the example uses OpenCV, the OpenCV requirements will be included in `docker-compose.yml`, which is used to run the application:
 
 ```sh
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT up
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT compose up
 
 # Terminate with Ctrl-C and cleanup
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT down --volumes
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT compose down --volumes
 ```
 
 ## License

--- a/parameter-api-cpp/README.md
+++ b/parameter-api-cpp/README.md
@@ -44,7 +44,8 @@ Meet the following requirements to ensure compatibility with the example:
   * [Docker ACAP](https://github.com/AxisCommunications/docker-acap) installed and started, using TLS and SD card as storage
   * [ACAP runtime](https://hub.docker.com/r/axisecp/acap-runtime) installed and started
 * Computer
-  * Either [Docker Desktop](https://docs.docker.com/desktop/) version 4.11.1 or higher, or [Docker Engine](https://docs.docker.com/engine/) version 20.10.17 or higher with BuildKit enabled using Docker Compose version 1.29.2 or higher
+  * Either [Docker Desktop](https://docs.docker.com/desktop/) version 4.11.1 or higher,
+  * or [Docker Engine](https://docs.docker.com/engine/) version 20.10.17 or higher with BuildKit enabled using Docker Compose version 1.29.2 or higher
 
 ## Proxy settings
 
@@ -135,10 +136,10 @@ docker save $APP_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT 
 With the application image on the device, it can be started using `docker-compose.yml`:
 
 ```sh
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT up
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT compose up
 
 # Cleanup
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT down --volumes
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT compose down --volumes
 ```
 
 ### The expected output

--- a/parameter-api-python/README.md
+++ b/parameter-api-python/README.md
@@ -42,7 +42,8 @@ Meet the following requirements to ensure compatibility with the example:
   * [Docker ACAP](https://github.com/AxisCommunications/docker-acap) installed and started, using TLS and SD card as storage
   * [ACAP runtime](https://hub.docker.com/r/axisecp/acap-runtime) installed and started
 * Computer
-  * Either [Docker Desktop](https://docs.docker.com/desktop/) version 4.11.1 or higher, or [Docker Engine](https://docs.docker.com/engine/) version 20.10.17 or higher with BuildKit enabled using Docker Compose version 1.29.2 or higher
+  * Either [Docker Desktop](https://docs.docker.com/desktop/) version 4.11.1 or higher,
+  * or [Docker Engine](https://docs.docker.com/engine/) version 20.10.17 or higher with BuildKit enabled using Docker Compose version 1.29.2 or higher
 
 ## Proxy settings
 
@@ -131,10 +132,10 @@ docker save $APP_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT 
 With the application image on the device, it can be started using `docker-compose.yml`:
 
 ```sh
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT up
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT compose up
 
 # Cleanup
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT down --volumes
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT compose down --volumes
 ```
 
 where `ca.pem`, `cert.pem` and `key.pem` are the certificates generated when configuring TLS on Docker ACAP.

--- a/pose-estimator-with-flask/README.md
+++ b/pose-estimator-with-flask/README.md
@@ -72,7 +72,8 @@ Meet the following requirements to ensure compatibility with the example:
   * Firmware: 10.9 or higher
   * [Docker ACAP](https://github.com/AxisCommunications/docker-acap) installed and started, using TLS and SD card as storage
 * Computer
-  * Either [Docker Desktop](https://docs.docker.com/desktop/) version 4.11.1 or higher, or [Docker Engine](https://docs.docker.com/engine/) version 20.10.17 or higher with BuildKit enabled using Docker Compose version 1.29.2 or higher
+  * Either [Docker Desktop](https://docs.docker.com/desktop/) version 4.11.1 or higher,
+  * or [Docker Engine](https://docs.docker.com/engine/) version 20.10.17 or higher with BuildKit enabled using Docker Compose version 1.29.2 or higher
 
 ## How to run the code
 
@@ -141,10 +142,10 @@ docker save $MODEL_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_POR
 With the application image on the device, it can be started using `docker-compose.yml`:
 
 ```sh
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP up
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP compose up
 
 # Terminate with Ctrl-C and cleanup
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP down --volumes
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT --env-file ./config/env.$ARCH.$CHIP compose down --volumes
 ```
 
 ### The expected output

--- a/web-server/README.md
+++ b/web-server/README.md
@@ -24,7 +24,8 @@ Meet the following requirements to ensure compatibility with the example:
   * Firmware: 10.9 or higher
   * [Docker ACAP](https://github.com/AxisCommunications/docker-acap) installed and started, using TLS and SD card as storage
 * Computer
-  * Either [Docker Desktop](https://docs.docker.com/desktop/) version 4.11.1 or higher, or [Docker Engine](https://docs.docker.com/engine/) version 20.10.17 or higher with BuildKit enabled using Docker Compose version 1.29.2 or higher
+  * Either [Docker Desktop](https://docs.docker.com/desktop/) version 4.11.1 or higher,
+  * or [Docker Engine](https://docs.docker.com/engine/) version 20.10.17 or higher with BuildKit enabled using Docker Compose version 1.29.2 or higher
 
 ## Limitations
 
@@ -105,10 +106,10 @@ docker save $APP_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT 
 With the application image on the device, it can be started using `docker-compose.yml`:
 
 ```sh
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT up
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT compose up
 
 # Terminate with Ctrl-C and cleanup
-docker-compose --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT down
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT compose down
 ```
 
 ### The expected output


### PR DESCRIPTION
### Describe your changes

From July 2023 Compose V1 stopped receiving updates. It’s also no longer available in new releases of Docker Desktop.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
