### PR TITLE
Fix ACAP Runtime mention and Docker ACAP

### DIFF
--- a/hello-world-cpp/README.md
+++ b/hello-world-cpp/README.md
@@ -30,7 +30,7 @@ Meet the following requirements to ensure compatibility with the example:
 * Axis device
   * Chip: ARTPEC-{7-8} DLPU devices (e.g., Q1615 MkIII)
   * Firmware: 10.9 or higher
-  * [Docker ACAP](https://github.com/AxisCommunications/docker-acap) installed and started, using TLS and SD card as storage
+  * [Docker ACAP](https://github.com/AxisCommunications/docker-acap#installing) installed and started, using TLS and SD card as storage
 * Computer
   * Either [Docker Desktop](https://docs.docker.com/desktop/) version 4.11.1 or higher,
   * or [Docker Engine](https://docs.docker.com/engine/) version 20.10.17 or higher with BuildKit enabled using Docker Compose version 1.29.2 or higher
@@ -51,7 +51,7 @@ export ARCH=aarch64
 
 ### Build the Docker image
 
-With the architecture defined, the `hello-world-cpp` image can be built. The environment variables are supplied as build arguments such that they are made available to docker during the build process:
+With the architecture defined, the `hello-world-cpp` image can be built. The environment variables are supplied as build arguments such that they are made available to Docker during the build process:
 
 ```sh
 # Define app name
@@ -70,11 +70,11 @@ DOCKER_PORT=2376
 docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT system prune --all --force
 ```
 
-If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap).
+If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap#securing-the-docker-acap-using-tls).
 
 ### Install the image
 
-Next, the built image needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
+Next, the built image needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's Docker client:
 
 ```sh
 docker save $APP_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT load

--- a/hello-world-python/README.md
+++ b/hello-world-python/README.md
@@ -4,7 +4,7 @@
 
 This example demonstrates how to create a simple Python application using the ACAP Computer Vision SDK and run it on an edge device.
 
-Going from zero to a Python application running on an AXIS device is quite easy. First, the application script is written, as in the hello-world script in [app/simply_hello.py](app/simply_hello.py). Next, the [Dockerfile](Dockerfile) which build the application image is constructed. This needs to pull in packages from the ACAP Computer Vision SDK, as is done using the `COPY` commands. Finally, the application needs to be built and uploaded, as is specified below.
+Going from zero to a Python application running on an AXIS device is quite easy. First, the application script is written, as in the hello-world script in [app/simply_hello.py](app/simply_hello.py). Next, the [Dockerfile](Dockerfile) which builds the application image is constructed. This needs to pull in packages from the ACAP Computer Vision SDK, as is done using the `COPY` commands. Finally, the application needs to be built and uploaded, as is specified below.
 
 ## Example structure
 
@@ -30,7 +30,7 @@ Meet the following requirements to ensure compatibility with the example:
 * Axis device
   * Chip: ARTPEC-{7-8} DLPU devices (e.g., Q1615 MkIII)
   * Firmware: 10.9 or higher
-  * [Docker ACAP](https://github.com/AxisCommunications/docker-acap) installed and started, using TLS and SD card as storage
+  * [Docker ACAP](https://github.com/AxisCommunications/docker-acap#installing) installed and started, using TLS and SD card as storage
 * Computer
   * Either [Docker Desktop](https://docs.docker.com/desktop/) version 4.11.1 or higher,
   * or [Docker Engine](https://docs.docker.com/engine/) version 20.10.17 or higher with BuildKit enabled using Docker Compose version 1.29.2 or higher
@@ -51,7 +51,7 @@ export ARCH=aarch64
 
 ### Build the Docker image
 
-With the architecture defined, the `hello-world-python` image can be built. The environment variables are supplied as build arguments such that they are made available to docker during the build process:
+With the architecture defined, the `hello-world-python` image can be built. The environment variables are supplied as build arguments such that they are made available to Docker during the build process:
 
 ```sh
 # Define app name
@@ -69,11 +69,11 @@ DOCKER_PORT=2376
 docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT system prune --all --force
 ```
 
-If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap).
+If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap#securing-the-docker-acap-using-tls).
 
 ### Install the image
 
-Next, the built image needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
+Next, the built image needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's Docker client:
 
 ```sh
 docker save $APP_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT load

--- a/object-detector-python/README.md
+++ b/object-detector-python/README.md
@@ -11,14 +11,9 @@ This example is written in Python and implements the following object detection 
 
 This example composes three different container images into an application that performs object detection using a deep learning model.
 
-The first container contains the actual program being built here, which uses OpenCV to capture pictures from the camera and modifies them to fit the input required by the model. It then uses grpc/protobuf to call the second container, the "inference-server", that performs the actual inference. The inference server implements the TensorFlow Serving API.
+The first container contains the actual program built in this example. It uses [OpenCV](https://opencv.org/) to capture pictures from the camera and modifies them to fit the input required by the model. It then uses [gRPC](https://grpc.io/)/[protobuf](https://developers.google.com/protocol-buffers) to call the second container, the *inference-server*, that performs the actual inference by implementing the [TensorFlow Serving API](https://github.com/tensorflow/serving). You can find more documentation on the [Machine Learning API documentation page](https://axiscommunications.github.io/acap-documentation/docs/api/computer-vision-sdk-apis.html#machine-learning-api). This example uses a containerized version of the [ACAP Runtime](https://github.com/AxisCommunications/acap-runtime#containerized-version) as the *inference-server*.
 
-Lastly, there is a third container that holds the deep learning model, which is put into a volume that is accessible to the other two images.
-
-**acap runtime**\
-Uses larod service in the camera firmware with the model you provide in your docker image
-
-The docker image containing the model has a layout as shown below. What model to use is specified by path in the docker-compose file.
+Lastly, there is a third container that holds the deep learning model, which is put into a volume that is accessible by the other two images. The layout of the Docker image containing the model is shown below. The *MODEL_PATH* variable in the configuration file you're using specifies what model to use. By default, the armv7hf configuration file uses the edgetpu model, while the aarch64 configuration file uses the vanilla model.
 
 ```text
 model
@@ -45,8 +40,8 @@ object-detector-python
 
 * **detector.py** - The inference client main program
 * **dog416.png** - Static image used with static-image.yml
-* **docker-compose.yml** - Docker compose file for streaming camera video example using larod inference service
-* **static-image.yml** - Docker compose file for static image debug example using larod inference service
+* **docker-compose.yml** - Docker compose file for streaming camera video example using larod inference server
+* **static-image.yml** - Docker compose file for static image debug example using larod inference server
 * **Dockerfile** - Build Docker image with inference client for camera
 * **Dockerfile.model** - Build Docker image with inference model
 
@@ -57,7 +52,7 @@ Meet the following requirements to ensure compatibility with the example:
 * Axis device
   * Chip: ARTPEC-{7-8} DLPU devices (e.g., Q1615 MkIII)
   * Firmware: 10.9 or higher
-  * [Docker ACAP](https://github.com/AxisCommunications/docker-acap) installed and started, using TLS and SD card as storage
+  * [Docker ACAP](https://github.com/AxisCommunications/docker-acap#installing) installed and started, using TLS and SD card as storage
 * Computer
   * Either [Docker Desktop](https://docs.docker.com/desktop/) version 4.11.1 or higher,
   * or [Docker Engine](https://docs.docker.com/engine/) version 20.10.17 or higher with BuildKit enabled using Docker Compose version 1.29.2 or higher
@@ -86,7 +81,7 @@ export CHIP=artpec8
 
 ### Build the Docker images
 
-With the architecture defined, the `acap4-object-detector-python` and `acap-dl-models` images can be built. The environment variables are supplied as build arguments such that they are made available to docker during the build process:
+With the architecture defined, the `acap4-object-detector-python` and `acap-dl-models` images can be built. The environment variables are supplied as build arguments such that they are made available to Docker during the build process:
 
 ```sh
 # Define app name
@@ -112,17 +107,23 @@ DOCKER_PORT=2376
 docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT system prune --all --force
 ```
 
-If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap).
+If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap#securing-the-docker-acap-using-tls).
 
 ### Install the images
 
-Next, the built images needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
+Next, the built images needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's Docker client:
 
 ```sh
 docker save $APP_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT load
 
 docker save $MODEL_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT load
 ```
+
+> [!NOTE]
+> If the *inference-server* ([containerized ACAP Runtime](https://github.com/AxisCommunications/acap-runtime#containerized-version)) is not already present on the device, it will be pulled from Docker Hub
+> when running `docker compose up`.
+> If the pull action fails due to network connectivity, pull the image to your host system and load it to
+> the device instead.
 
 ### Run the containers
 

--- a/opencv-image-capture-cpp/README.md
+++ b/opencv-image-capture-cpp/README.md
@@ -23,7 +23,7 @@ Meet the following requirements to ensure compatibility with the example:
 * Axis device
   * Chip: ARTPEC-{7-8} DLPU devices (e.g., Q1615 MkIII)
   * Firmware: 10.9 or higher
-  * [Docker ACAP](https://github.com/AxisCommunications/docker-acap) installed and started, using TLS and SD card as storage
+  * [Docker ACAP](https://github.com/AxisCommunications/docker-acap#installing) installed and started, using TLS and SD card as storage
 * Computer
   * Either [Docker Desktop](https://docs.docker.com/desktop/) version 4.11.1 or higher,
   * or [Docker Engine](https://docs.docker.com/engine/) version 20.10.17 or higher with BuildKit enabled using Docker Compose version 1.29.2 or higher
@@ -45,7 +45,7 @@ opencv-image-capture-cpp
 
 * **capture.cpp**        - Example application to capture camera properties such as time stamps, zoom, focus etc.
 * **Dockerfile**         - Docker file with the toolchain included to run the example.
-* **docker-compose.yml** - Docker compose file contains the latest image of the example from dockerhub.
+* **docker-compose.yml** - Docker compose file contains the latest image of the example from DockerHub.
 * **README.md**          - Step by step instructions on how to run the example.
 
 ### Limitations
@@ -69,7 +69,7 @@ export ARCH=aarch64
 
 ### Build the Docker image
 
-With the architecture defined, the `acap-opencv-image-capture-cpp` image can be built. The environment variables are supplied as build arguments such that they are made available to docker during the build process:
+With the architecture defined, the `acap-opencv-image-capture-cpp` image can be built. The environment variables are supplied as build arguments such that they are made available to Docker during the build process:
 
 ```sh
 # Define app name
@@ -87,11 +87,11 @@ DOCKER_PORT=2376
 docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT system prune --all --force
 ```
 
-If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap).
+If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap#securing-the-docker-acap-using-tls).
 
 ### Install the image
 
-Next, the built image needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
+Next, the built image needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's Docker client:
 
 ```sh
 docker save $APP_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT load

--- a/opencv-qr-decoder-python/README.md
+++ b/opencv-qr-decoder-python/README.md
@@ -32,7 +32,7 @@ Meet the following requirements to ensure compatibility with the example:
 * Axis device
   * Chip: ARTPEC-{7-8} DLPU devices (e.g., Q1615 MkIII)
   * Firmware: 10.9 or higher
-  * [Docker ACAP](https://github.com/AxisCommunications/docker-acap) installed and started, using TLS and SD card as storage
+  * [Docker ACAP](https://github.com/AxisCommunications/docker-acap#installing) installed and started, using TLS and SD card as storage
 * Computer
   * Either [Docker Desktop](https://docs.docker.com/desktop/) version 4.11.1 or higher,
   * or [Docker Engine](https://docs.docker.com/engine/) version 20.10.17 or higher with BuildKit enabled using Docker Compose version 1.29.2 or higher
@@ -53,7 +53,7 @@ export ARCH=aarch64
 
 ### Build the Docker image
 
-With the architecture defined, the `acap-opencv-qr-decoder-python` image can be built. The environment variables are supplied as build arguments such that they are made available to docker during the build process:
+With the architecture defined, the `acap-opencv-qr-decoder-python` image can be built. The environment variables are supplied as build arguments such that they are made available to Docker during the build process:
 
 ```sh
 # Define app name
@@ -71,11 +71,11 @@ DOCKER_PORT=2376
 docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT system prune --all --force
 ```
 
-If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap).
+If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap#securing-the-docker-acap-using-tls).
 
 ### Install the image
 
-Next, the built images needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
+Next, the built images needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's Docker client:
 
 ```sh
 docker save $APP_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT load

--- a/parameter-api-cpp/README.md
+++ b/parameter-api-cpp/README.md
@@ -4,11 +4,11 @@
 
 [![Build parameter-api-cpp application](https://github.com/AxisCommunications/acap-computer-vision-sdk-examples/actions/workflows/parameter-api-cpp.yml/badge.svg)](https://github.com/AxisCommunications/acap-computer-vision-sdk-examples/actions/workflows/parameter-api-cpp.yml)
 
-The example is written in C++ and communicates with the [ACAP runtime](https://hub.docker.com/r/axisecp/acap-runtime) using gRPC on a Unix Domain Socket (UDS). ACAP runtime acts as a server that exposes the Parameter-API.
+The example is written in C++ and communicates with the [ACAP Runtime](https://github.com/AxisCommunications/acap-runtime#native-acap-application) using gRPC on a Unix Domain Socket (UDS). ACAP Runtime acts as a server that exposes the Parameter-API.
 
 ## Overview
 
-A network device from Axis has a lot of parameters and in this example we will use the Parameter-API, a service in [ACAP runtime](https://hub.docker.com/r/axisecp/acap-runtime) to read the values of a set of parameters and print them to the application log. The Parameter-API can read parameters, but cannot read parameter groups nor set parameter values.It is necessary to use the exact parameter name to get the expected results. The parameter list can be found using the URL `http://<ip address>/axis-cgi/param.cgi?action=list` where `<ip address>` is the IP address of your device.
+A network device from Axis has a lot of parameters and in this example we will use the Parameter-API, a service in [ACAP Runtime](https://github.com/AxisCommunications/acap-runtime) to read the values of a set of parameters and print them to the application log. The Parameter-API can read parameters, but cannot read parameter groups nor set parameter values.It is necessary to use the exact parameter name to get the expected results. The parameter list can be found using the URL `http://<ip address>/axis-cgi/param.cgi?action=list` where `<ip address>` is the IP address of your device.
 
 ## Example structure
 
@@ -41,8 +41,8 @@ Meet the following requirements to ensure compatibility with the example:
 * Axis device
   * Chip: ARTPEC-{7-8} DLPU devices (e.g., Q1615 MkIII)
   * Firmware: 10.9 or higher
-  * [Docker ACAP](https://github.com/AxisCommunications/docker-acap) installed and started, using TLS and SD card as storage
-  * [ACAP runtime](https://hub.docker.com/r/axisecp/acap-runtime) installed and started
+  * [Docker ACAP](https://github.com/AxisCommunications/docker-acap#installing) installed and started, using TLS and SD card as storage
+  * [ACAP Runtime](https://github.com/AxisCommunications/acap-runtime#native-acap-application) installed and started
 * Computer
   * Either [Docker Desktop](https://docs.docker.com/desktop/) version 4.11.1 or higher,
   * or [Docker Engine](https://docs.docker.com/engine/) version 20.10.17 or higher with BuildKit enabled using Docker Compose version 1.29.2 or higher
@@ -69,7 +69,7 @@ export ARCH=aarch64
 
 ### Build the Docker image
 
-With the architecture defined, the `parameter-api` image can be built. The environment variables are supplied as build arguments such that they are made available to docker during the build process:
+With the architecture defined, the `parameter-api` image can be built. The environment variables are supplied as build arguments such that they are made available to Docker during the build process:
 
 ```sh
 # Define app name
@@ -88,7 +88,7 @@ DOCKER_PORT=2376
 docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT system prune --all --force
 ```
 
-If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap).
+If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap#securing-the-docker-acap-using-tls).
 
 ### Install the image and required server certificates
 
@@ -98,7 +98,7 @@ To use SSL/TLS server authentication and encryption, a server certificate is pro
     entrypoint: /usr/bin/parameter /certificates/server.pem
 ```
 
-Certificate files for TLS are created in the build process of this example and must be copied to ACAP runtime folder on the device:
+Certificate files for TLS are created in the build process of this example and must be copied to ACAP Runtime folder on the device:
 
 ```sh
 docker cp $(docker create $APP_NAME):/certificates .
@@ -111,7 +111,7 @@ Use SSH to change the ownership of the files on the device:
 ssh root@$DEVICE_IP 'chown sdk /usr/local/packages/acapruntime/server.*'
 ```
 
-After copying the server certificates onto the device, we have to make sure to enable TLS and then restart the ACAP-runtime.
+After copying the server certificates onto the device, we have to make sure to enable TLS and then restart the ACAP Runtime.
 
 ```sh
 AXIS_TARGET_PASSWORD='<password>'
@@ -125,7 +125,7 @@ curl --anyauth -u "root:$AXIS_TARGET_PASSWORD" "$DEVICE_IP/axis-cgi/applications
 
 where `<password>` is the password to the `root` user.
 
-Finally install the application image to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
+Finally install the application image to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's Docker client:
 
 ```sh
 docker save $APP_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT load

--- a/parameter-api-python/README.md
+++ b/parameter-api-python/README.md
@@ -4,11 +4,11 @@
 
 [![Build parameter-api-python application](https://github.com/AxisCommunications/acap-computer-vision-sdk-examples/actions/workflows/parameter-api-python.yml/badge.svg)](https://github.com/AxisCommunications/acap-computer-vision-sdk-examples/actions/workflows/parameter-api-python.yml)
 
-The example is written in Python and communicates with the [ACAP runtime](https://hub.docker.com/r/axisecp/acap-runtime) using gRPC on a Unix Domain Socket (UDS). ACAP runtime acts as a server that exposes the Parameter-API.
+The example is written in Python and communicates with the [ACAP Runtime](https://github.com/AxisCommunications/acap-runtime#native-acap-application) using gRPC on a Unix Domain Socket (UDS). ACAP Runtime acts as a server that exposes the Parameter-API.
 
 ## Overview
 
-A network device from Axis has a lot of parameters and in this example we will use the Parameter-API, a service in [ACAP runtime](https://hub.docker.com/r/axisecp/acap-runtime) to read the values of a set of parameters and print them to the application log. The Parameter-API can read parameters, but cannot read parameter groups nor set parameter values.It is necessary to use the exact parameter name to get the expected results. The parameter list can be found using the URL `http://<ip address>/axis-cgi/param.cgi?action=list` where `<ip address>` is the IP address of your device.
+A network device from Axis has a lot of parameters and in this example we will use the Parameter-API, a service in [ACAP Runtime](https://github.com/AxisCommunications/acap-runtime) to read the values of a set of parameters and print them to the application log. The Parameter-API can read parameters, but cannot read parameter groups nor set parameter values.It is necessary to use the exact parameter name to get the expected results. The parameter list can be found using the URL `http://<ip address>/axis-cgi/param.cgi?action=list` where `<ip address>` is the IP address of your device.
 
 ## Example structure
 
@@ -39,8 +39,8 @@ Meet the following requirements to ensure compatibility with the example:
 * Axis device
   * Chip: ARTPEC-{7-8} DLPU devices (e.g., Q1615 MkIII)
   * Firmware: 10.9 or higher
-  * [Docker ACAP](https://github.com/AxisCommunications/docker-acap) installed and started, using TLS and SD card as storage
-  * [ACAP runtime](https://hub.docker.com/r/axisecp/acap-runtime) installed and started
+  * [Docker ACAP](https://github.com/AxisCommunications/docker-acap#installing) installed and started, using TLS and SD card as storage
+  * [ACAP Runtime](https://github.com/AxisCommunications/acap-runtime#native-acap-application) installed and started
 * Computer
   * Either [Docker Desktop](https://docs.docker.com/desktop/) version 4.11.1 or higher,
   * or [Docker Engine](https://docs.docker.com/engine/) version 20.10.17 or higher with BuildKit enabled using Docker Compose version 1.29.2 or higher
@@ -84,7 +84,7 @@ DOCKER_PORT=2376
 docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT system prune --all --force
 ```
 
-If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap).
+If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap#securing-the-docker-acap-using-tls).
 
 ### Install the image and required server certificates
 
@@ -94,7 +94,7 @@ To use SSL/TLS server authentication and encryption, a server certificate is pro
     entrypoint: python3 parameter.py /certificates/server.pem
 ```
 
-Certificate files for TLS are created in the build process of this example and must be copied to ACAP runtime folder on the device:
+Certificate files for TLS are created in the build process of this example and must be copied to ACAP Runtime folder on the device:
 
 ```sh
 docker cp $(docker create $APP_NAME):/certificates .
@@ -107,7 +107,7 @@ Use SSH to change the ownership of the files on the device:
 ssh root@$DEVICE_IP 'chown sdk /usr/local/packages/acapruntime/server.*'
 ```
 
-After copying the server certificates onto the device, we have to make sure to enable TLS and then restart the ACAP-runtime.
+After copying the server certificates onto the device, we have to make sure to enable TLS and then restart the ACAP Runtime.
 
 ```sh
 AXIS_TARGET_PASSWORD='<password>'

--- a/pose-estimator-with-flask/README.md
+++ b/pose-estimator-with-flask/README.md
@@ -11,9 +11,15 @@ The model [MoveNet SinglePose Lightning](https://coral.ai/models/pose-estimation
 
 This example composes three different container images into an application that performs object detection using a deep learning model.
 
-The first container contains the actual program built in this example. It uses [OpenCV](https://opencv.org/) to capture pictures from the camera and modifies them to fit the input required by the model. It then uses [gRPC](https://grpc.io/)/[protobuf](https://developers.google.com/protocol-buffers) to call the second container, the *inference server*, that performs the actual inference. The inference server implements the [TensorFlow Serving API](https://github.com/tensorflow/serving).
+The first container contains the actual program built in this example. It uses [OpenCV](https://opencv.org/) to capture pictures from the camera and modifies them to fit the input required by the model. It then uses [gRPC](https://grpc.io/)/[protobuf](https://developers.google.com/protocol-buffers) to call the second container, the *inference-server*, that performs the actual inference by implementing the [TensorFlow Serving API](https://github.com/tensorflow/serving). You can find more documentation on the [Machine Learning API documentation page](https://axiscommunications.github.io/acap-documentation/docs/api/computer-vision-sdk-apis.html#machine-learning-api). This example uses a containerized version of the [ACAP Runtime](https://github.com/AxisCommunications/acap-runtime#containerized-version) as the *inference-server*.
 
-Lastly, there is a third container that holds the deep learning model, which is put into a volume that is accessible by the other two images.
+Lastly, there is a third container that holds the deep learning model, which is put into a volume that is accessible by the other two images. The layout of the Docker image containing the model is shown below. The *MODEL_PATH* variable in the configuration file you're using specifies what model to use. By default, the armv7hf configuration file uses the edgetpu model, while the aarch64 configuration file uses the vanilla model.
+
+```text
+model
+├── movenet_single_pose_lightning_ptq.tflite - model for CPU and DLPU
+└── movenet_single_pose_lightning_ptq_edgetpu.tflite - model for TPU
+```
 
 ### Applications
 
@@ -22,19 +28,6 @@ Pose estimation is useful to accomplish several tasks. For example in action det
 * autonomous driving, to detect if a pedestrian is waiting or crossing a street
 * healthcare, to detect if a person is standing or falling.
 Pose estimation models are also considered better than object detection at tracking humans. That is because they can keep tracking the human under partial occlusion, where a classic object detection model is more prone to fail.
-
-### larod-inference server
-
-This image uses the larod service in AXIS OS and the model from the installed model image.
-You can find documentation about the larod inference server on the [Machine Learning API documentation page](https://axiscommunications.github.io/acap-documentation/docs/api/native-api.html#machine-learning-api)
-
-The layout of the Docker image containing the model is shown below. The *MODEL_PATH* variable in the configuration file you're using specifies what model to use. By default, the armv7hf configuration file uses the edgetpu model, while the aarch64 configuration file uses the vanilla model.
-
-```text
-model
-├── movenet_single_pose_lightning_ptq.tflite for CPU and DLPU
-└── movenet_single_pose_lightning_ptq_edgetpu.tflite for TPU
-```
 
 ## Example structure
 
@@ -59,7 +52,7 @@ pose-estimator-with-flask
 * **app/pose-estimator-with-flask.py** - The inference client main program
 * **config/env.aarch64** - Configuration file for Docker Compose to run on aarch64 devices
 * **config/env.armv7hf** - Configuration file for Docker Compose to run on armv7hf devices
-* **docker-compose.yml** - Docker Compose file for streaming camera video example using larod inference service
+* **docker-compose.yml** - Docker Compose file for streaming camera video example using larod inference server
 * **Dockerfile** - Docker image with inference client for camera
 * **Dockerfile.model** - Docker image with inference model
 
@@ -70,7 +63,7 @@ Meet the following requirements to ensure compatibility with the example:
 * Axis device
   * Chip: ARTPEC-{7-8} DLPU devices (e.g., Q1615 MkIII)
   * Firmware: 10.9 or higher
-  * [Docker ACAP](https://github.com/AxisCommunications/docker-acap) installed and started, using TLS and SD card as storage
+  * [Docker ACAP](https://github.com/AxisCommunications/docker-acap#installing) installed and started, using TLS and SD card as storage
 * Computer
   * Either [Docker Desktop](https://docs.docker.com/desktop/) version 4.11.1 or higher,
   * or [Docker Engine](https://docs.docker.com/engine/) version 20.10.17 or higher with BuildKit enabled using Docker Compose version 1.29.2 or higher
@@ -99,7 +92,7 @@ export CHIP=artpec8
 
 ### Build the Docker images
 
-With the architecture defined, the `acap4-pose-estimator-python` and `acap-dl-models` images can be built. The environment variables are supplied as build arguments such that they are made available to docker during the build process:
+With the architecture defined, the `acap4-pose-estimator-python` and `acap-dl-models` images can be built. The environment variables are supplied as build arguments such that they are made available to Docker during the build process:
 
 ```sh
 # Define app name
@@ -125,17 +118,23 @@ DOCKER_PORT=2376
 docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT system prune --all --force
 ```
 
-If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap).
+If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap#securing-the-docker-acap-using-tls).
 
 ### Install the images
 
-Next, the built images needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
+Next, the built images needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's Docker client:
 
 ```sh
 docker save $APP_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT load
 
 docker save $MODEL_NAME | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT load
 ```
+
+> [!NOTE]
+> If the *inference-server* ([containerized ACAP Runtime](https://github.com/AxisCommunications/acap-runtime#containerized-version)) is not already present on the device, it will be pulled from Docker Hub
+> when running `docker compose up`.
+> If the pull action fails due to network connectivity, pull the image to your host system and load it to
+> the device instead.
 
 ### Run the containers
 
@@ -145,7 +144,7 @@ With the application image on the device, it can be started using `docker-compos
 docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT compose --env-file ./config/env.$ARCH.$CHIP up
 
 # Terminate with Ctrl-C and cleanup
-docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT compose --env-file ./config/env.$ARCH.$CHIP down --volumes
+docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT compose --env-file ./config/env.$ARCH.$CHIP compose down --volumes
 ```
 
 ### The expected output

--- a/web-server/README.md
+++ b/web-server/README.md
@@ -22,7 +22,7 @@ Meet the following requirements to ensure compatibility with the example:
 * Axis device
   * Chip: ARTPEC-{7-8} DLPU devices (e.g., Q1615 MkIII)
   * Firmware: 10.9 or higher
-  * [Docker ACAP](https://github.com/AxisCommunications/docker-acap) installed and started, using TLS and SD card as storage
+  * [Docker ACAP](https://github.com/AxisCommunications/docker-acap#installing) installed and started, using TLS and SD card as storage
 * Computer
   * Either [Docker Desktop](https://docs.docker.com/desktop/) version 4.11.1 or higher,
   * or [Docker Engine](https://docs.docker.com/engine/) version 20.10.17 or higher with BuildKit enabled using Docker Compose version 1.29.2 or higher
@@ -67,7 +67,7 @@ export ARCH=aarch64
 
 ### Build the Docker image
 
-With the architecture defined, the `monkey` image can be built. The environment variables are supplied as build arguments such that they are made available to docker during the build process:
+With the architecture defined, the `monkey` image can be built. The environment variables are supplied as build arguments such that they are made available to Docker during the build process:
 
 ```sh
 # Define app name
@@ -89,11 +89,11 @@ DOCKER_PORT=2376
 docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT system prune --all --force
 ```
 
-If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap).
+If you encounter any TLS related issues, please see the TLS setup chapter regarding the `DOCKER_CERT_PATH` environment variable in the [Docker ACAP repository](https://github.com/AxisCommunications/docker-acap#securing-the-docker-acap-using-tls).
 
 ### Install the image
 
-Next, the built image needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's docker client:
+Next, the built image needs to be uploaded to the device. This can be done through a registry or directly. In this case, the direct transfer is used by piping the compressed application directly to the device's Docker client:
 
 ```sh
 


### PR DESCRIPTION
### Describe your changes

- Clarify the use of ACAP Runtime in some examples
- Link to ACAP Runtime and Docker ACAP on Github instead of Docker Hub
